### PR TITLE
Avoid name collisions while computing `reuseIdentifier`

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		74C7FEA22083A9B4005C8B53 /* Kingfisher.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 74C7FEA02083A9B4005C8B53 /* Kingfisher.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		74C7FEA42083AC0E005C8B53 /* ReactiveFeedback.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74C7FEA32083AC0E005C8B53 /* ReactiveFeedback.framework */; };
 		74C7FEA52083AC0E005C8B53 /* ReactiveFeedback.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 74C7FEA32083AC0E005C8B53 /* ReactiveFeedback.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A67A873520B5D2D100BC2BAC /* RenderableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67A873420B5D2D100BC2BAC /* RenderableTests.swift */; };
 		A95093B3B7AD6DC69644BCA6 /* SectionedFormAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9509BC2762C8B4277B973D8 /* SectionedFormAdapter.swift */; };
 		A9509880661501C40B50E453 /* TableViewHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A950970749997A21E1BF7777 /* TableViewHeaderFooterView.swift */; };
 		A9509C4FC3664040FF3649CD /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95093DB10046D731018127D /* Node.swift */; };
@@ -160,6 +161,7 @@
 		9A7846FE205EAF8400FA597E /* SectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTests.swift; sourceTree = "<group>"; };
 		9A784700205EB5E000FA597E /* TestRenderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRenderable.swift; sourceTree = "<group>"; };
 		9A784702205EB61D00FA597E /* TestId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestId.swift; sourceTree = "<group>"; };
+		A67A873420B5D2D100BC2BAC /* RenderableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderableTests.swift; sourceTree = "<group>"; };
 		A95093DB10046D731018127D /* Node.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		A950967CC717BBF3B02B766D /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		A950970749997A21E1BF7777 /* TableViewHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderFooterView.swift; sourceTree = "<group>"; };
@@ -311,6 +313,7 @@
 		58FC441E207CF29F00DA3614 /* BentoTests */ = {
 			isa = PBXGroup;
 			children = (
+				A67A873420B5D2D100BC2BAC /* RenderableTests.swift */,
 				9A3EF77F205D866F00D043AC /* AnyRenderableTests.swift */,
 				9A7846FC205EAF7C00FA597E /* NodeTests.swift */,
 				9A7846FE205EAF8400FA597E /* SectionTests.swift */,
@@ -553,6 +556,7 @@
 				740921B620ACDDDA00B59F5C /* IfTests.swift in Sources */,
 				58FC442B207CF2BB00DA3614 /* SectionTests.swift in Sources */,
 				740921B820ACE5EC00B59F5C /* ConcatenationTests.swift in Sources */,
+				A67A873520B5D2D100BC2BAC /* RenderableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bento/Renderable/Renderable.swift
+++ b/Bento/Renderable/Renderable.swift
@@ -17,7 +17,8 @@ public extension Renderable where Self: AnyObject {
 
 public extension Renderable {
     var reuseIdentifier: String {
-        return String(describing: View.self)
+        /// Returns the demangled qualified name of View
+        return _typeName(View.self, qualified: true)
     }
 }
 

--- a/BentoTests/RenderableTests.swift
+++ b/BentoTests/RenderableTests.swift
@@ -1,0 +1,40 @@
+import Nimble
+import XCTest
+import UIKit
+@testable import Bento
+
+import XCTest
+
+class RenderableTests: XCTestCase {
+    
+    func testReuseIdentifierWithoutNameCollisions() {
+        expect(Component.Text().reuseIdentifier) != Component.Image().reuseIdentifier
+    }
+}
+
+enum Component {}
+
+extension Component {
+
+    final class Text: Renderable {
+        func render(in view: View) {}
+    }
+}
+
+extension Component.Text {
+
+    public final class View: UIView {}
+}
+
+extension Component {
+
+    final class Image: Renderable {
+
+        func render(in view: View) {}
+    }
+}
+
+extension Component.Image {
+
+    public final class View: UIView {}
+}


### PR DESCRIPTION
### Context

`String(describing: View.self)` does not include any information about the namespace where it's defined leading to potential name collisions, which in this case means using the same identifier for views completely different.

Take as an example the following snippet where we define two components, `Text` and `Image`, and both define their inner view, `View` in their own namespace. The reuse identifier will be `"View"` i n both components. There's also the case where name collisions can appear between components defined in different modules.

```swift
enum Component {}

extension Component {

    final class Text: Renderable {
        func render(in view: View) {}
    }
}

extension Component.Text {

    public final class View: UIView {}
}

extension Component {

    final class Image: Renderable {

        func render(in view: View) {}
    }
}

extension Component.Image {

    public final class View: UIView {}
}
```

### Solution

`_typeName(_:qualified:)` is a Swift function that returns the demangled qualified name of a metatype which means will include the entire namespace where it's defined plus the module name which its part of.

This function is used by `String(reflecting:)` when the subject does not conform to neither of the following protocols:

- `CustomDebugStringConvertible`
- `CustomStringConvertible`
- `TextOutputStreamable`

Considering the example above this will lead to the following identifiers:

- `Component.Text`: `"{Module}.Component.Text.View"`
- `Component.Image`: `"{Module}.Component.Image.View"`

This avoids any collisions while reusing views associated to any of this components even when the actual view shares the same name.