### PR TITLE
Replace `_typeName(_:qualified:)` by `String(reflecting:)` which is safe for metatypes

### DIFF
--- a/Bento/Renderable/Renderable.swift
+++ b/Bento/Renderable/Renderable.swift
@@ -17,8 +17,7 @@ public extension Renderable where Self: AnyObject {
 
 public extension Renderable {
     var reuseIdentifier: String {
-        /// Returns the demangled qualified name of View
-        return _typeName(View.self, qualified: true)
+        return String(reflecting: View.self)
     }
 }
 


### PR DESCRIPTION
`String(reflecting:)` is unsafe for instances since they can implement `CustomDebugStringConvertible` or `CustomStringConvertible` which could lead to dynamic values depending on the internal state but when applied to metatypes it's safe and can be used as the implementation for the default `reuseIdentifier`.