### PR TITLE
Add sizeBoundTo to Node and Section

### DIFF
--- a/Bento/Bento/Node.swift
+++ b/Bento/Bento/Node.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 public struct Node<Identifier: Hashable>: Equatable {
-    let id: Identifier
+    public let id: Identifier
     let component: AnyRenderable
 
     init(id: Identifier, component: AnyRenderable) {
@@ -15,6 +15,18 @@ public struct Node<Identifier: Hashable>: Equatable {
 
     public static func == (lhs: Node, rhs: Node) -> Bool {
         return lhs.id == rhs.id && lhs.component == rhs.component
+    }
+
+    public func sizeBoundTo(width: CGFloat) -> CGSize {
+        return component.sizeBoundTo(width: width)
+    }
+
+    public func sizeBoundTo(height: CGFloat) -> CGSize {
+        return component.sizeBoundTo(height: height)
+    }
+
+    public func sizeBoundTo(size: CGSize) -> CGSize {
+        return component.sizeBoundTo(size: size)
     }
 }
 

--- a/Bento/Bento/Section.swift
+++ b/Bento/Bento/Section.swift
@@ -1,10 +1,10 @@
 import UIKit
 
 public struct Section<SectionId: Hashable, RowId: Hashable>: Equatable {
-    let id: SectionId
+    public let id: SectionId
+    public let rows: [Node<RowId>]
     let header: AnyRenderable?
     let footer: AnyRenderable?
-    let rows: [Node<RowId>]
 
     public init<Header: Renderable, Footer: Renderable>(id: SectionId,
                                                         header: Header,
@@ -51,6 +51,30 @@ public struct Section<SectionId: Hashable, RowId: Hashable>: Equatable {
         self.header = header
         self.footer = footer
         self.rows = rows
+    }
+
+    public func headerSizeBoundTo(width: CGFloat) -> CGSize {
+        return header?.sizeBoundTo(width: width) ?? .zero
+    }
+
+    public func headerSizeBoundTo(height: CGFloat) -> CGSize {
+        return header?.sizeBoundTo(height: height) ?? .zero
+    }
+
+    public func headerSizeBoundTo(size: CGSize) -> CGSize {
+        return header?.sizeBoundTo(size: size) ?? .zero
+    }
+
+    public func footerSizeBoundTo(width: CGFloat) -> CGSize {
+        return footer?.sizeBoundTo(width: width) ?? .zero
+    }
+
+    public func footerSizeBoundTo(height: CGFloat) -> CGSize {
+        return footer?.sizeBoundTo(height: height) ?? .zero
+    }
+
+    public func footerSizeBoundTo(size: CGSize) -> CGSize {
+        return footer?.sizeBoundTo(size: size) ?? .zero
     }
 
     public static func hasEqualMetadata(_ lhs: Section, _ rhs: Section) -> Bool {

--- a/Bento/Renderable/AnyRenderable.swift
+++ b/Bento/Renderable/AnyRenderable.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 struct AnyRenderable: Renderable {
-    var reuseIdentifier: String {
+    public var reuseIdentifier: String {
         return base.reuseIdentifier
     }
 
@@ -17,6 +17,32 @@ struct AnyRenderable: Renderable {
 
     func render(in view: UIView) {
         base.render(in: view)
+    }
+
+    func sizeBoundTo(width: CGFloat) -> CGSize {
+        return rendered()
+            .systemLayoutSizeFitting(CGSize(width: width, height: UILayoutFittingCompressedSize.height),
+                                                      withHorizontalFittingPriority: .required,
+                                                      verticalFittingPriority: .defaultLow)
+    }
+
+    func sizeBoundTo(height: CGFloat) -> CGSize {
+        return rendered()
+            .systemLayoutSizeFitting(CGSize(width: UILayoutFittingCompressedSize.width, height: height),
+                                     withHorizontalFittingPriority: .defaultLow,
+                                     verticalFittingPriority: .required)
+    }
+
+    func sizeBoundTo(size: CGSize) -> CGSize {
+        return rendered()
+            .systemLayoutSizeFitting(size)
+    }
+
+    private func rendered() -> UIView {
+        let view = generate()
+        render(in: view)
+
+        return view
     }
 
     static func ==(lhs: AnyRenderable, rhs: AnyRenderable) -> Bool {


### PR DESCRIPTION
### Why?

Sometimes it may be useful to be able to access array of nodes as well as `nodeId` if you would want to customise a layout of the `UICollectionView` etc.

There is also known [issue](https://github.com/Instagram/IGListKit/issues/516) with `UICollectionView` self sizing, it seams like it uses estimated size in the beginning 😕

In our [codebase](https://github.com/Babylonpartners/babylon-ios/commit/6efdd72fb2be1c212db936e1421d93e97480e783#diff-5b31e8e3c21392c84ce439bb0ef53a71R4) we are going to use `UICollectionViewDelegateFlowLayout` and `systemLayoutSizeFitting` to calculate item size

### Screenshots

Before | After
--- | ---
![self-sizing](https://user-images.githubusercontent.com/4622322/42682819-833e9140-8683-11e8-8a01-7a347e29a70c.gif) | ![using-adapter](https://user-images.githubusercontent.com/4622322/42682833-892e893e-8683-11e8-80d1-e9332168f1dd.gif)