### PR TITLE
Focus Control.

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -59,6 +59,15 @@
 		65496FB8211C323F00511D8A /* TableViewContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587F0717201B355800ACD219 /* TableViewContainerCell.swift */; };
 		65496FB9211C323F00511D8A /* TableViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9509BC2762C8B4277B973D8 /* TableViewAdapter.swift */; };
 		65BA922E20AF388F004AEF18 /* UITableViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BA922D20AF388F004AEF18 /* UITableViewExtensions.swift */; };
+		65E3ECA02113114100869DF3 /* Focusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3EC9F2113114100869DF3 /* Focusable.swift */; };
+		65E3ECA2211317EA00869DF3 /* FocusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECA1211317EA00869DF3 /* FocusCoordinator.swift */; };
+		65E3ECA421133BF700869DF3 /* FocusEligibilitySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECA321133BF700869DF3 /* FocusEligibilitySource.swift */; };
+		65E3ECA621133C9400869DF3 /* UIKit+CollectionViewFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECA521133C9400869DF3 /* UIKit+CollectionViewFocus.swift */; };
+		65E3ECA8211340CE00869DF3 /* PersonalDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECA7211340CE00869DF3 /* PersonalDetailsViewController.swift */; };
+		65E3ECAA2113448200869DF3 /* TextFieldComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECA92113448200869DF3 /* TextFieldComponent.swift */; };
+		65E3ECAC2113591500869DF3 /* FocusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECAB2113591500869DF3 /* FocusableView.swift */; };
+		65E3ECAE2113594600869DF3 /* BentoCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECAD2113594600869DF3 /* BentoCollectionView.swift */; };
+		65E3ECB02113598700869DF3 /* UIKit+BentoCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECAF2113598700869DF3 /* UIKit+BentoCollectionView.swift */; };
 		740921B620ACDDDA00B59F5C /* IfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740921B520ACDDDA00B59F5C /* IfTests.swift */; };
 		740921B820ACE5EC00B59F5C /* ConcatenationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740921B720ACE5EC00B59F5C /* ConcatenationTests.swift */; };
 		74208FA12083B1F00062CC8D /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74208FA22083B1F00062CC8D /* Nimble.framework */; };
@@ -168,6 +177,15 @@
 		61B64BB320873DA10092082C /* CollectionViewSectionDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewSectionDiff.swift; sourceTree = "<group>"; };
 		61B64BB5208745730092082C /* CollectionViewContainerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContainerCell.swift; sourceTree = "<group>"; };
 		65BA922D20AF388F004AEF18 /* UITableViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableViewExtensions.swift; sourceTree = "<group>"; };
+		65E3EC9F2113114100869DF3 /* Focusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Focusable.swift; sourceTree = "<group>"; };
+		65E3ECA1211317EA00869DF3 /* FocusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCoordinator.swift; sourceTree = "<group>"; };
+		65E3ECA321133BF700869DF3 /* FocusEligibilitySource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusEligibilitySource.swift; sourceTree = "<group>"; };
+		65E3ECA521133C9400869DF3 /* UIKit+CollectionViewFocus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIKit+CollectionViewFocus.swift"; sourceTree = "<group>"; };
+		65E3ECA7211340CE00869DF3 /* PersonalDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonalDetailsViewController.swift; sourceTree = "<group>"; };
+		65E3ECA92113448200869DF3 /* TextFieldComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldComponent.swift; sourceTree = "<group>"; };
+		65E3ECAB2113591500869DF3 /* FocusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusableView.swift; sourceTree = "<group>"; };
+		65E3ECAD2113594600869DF3 /* BentoCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BentoCollectionView.swift; sourceTree = "<group>"; };
+		65E3ECAF2113598700869DF3 /* UIKit+BentoCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIKit+BentoCollectionView.swift"; sourceTree = "<group>"; };
 		740921B520ACDDDA00B59F5C /* IfTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfTests.swift; sourceTree = "<group>"; };
 		740921B720ACE5EC00B59F5C /* ConcatenationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcatenationTests.swift; sourceTree = "<group>"; };
 		74208FA22083B1F00062CC8D /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -266,6 +284,7 @@
 			children = (
 				61B40915208523CE0063DE25 /* CollectionViewExample */,
 				58E98E542016570800F78BAE /* Cells */,
+				65E3ECA7211340CE00869DF3 /* PersonalDetailsViewController.swift */,
 				58FC444B207CFBE100DA3614 /* BookAppointmentViewController.swift */,
 				58FC444C207CFBE200DA3614 /* MoviesListViewController.swift */,
 				5829D268200FB092001E020D /* AppDelegate.swift */,
@@ -323,6 +342,7 @@
 				58E98E552016571F00F78BAE /* IconTextCell.xib */,
 				58E98E572016571F00F78BAE /* ToggleCell.swift */,
 				58E98E562016571F00F78BAE /* ToggleCell.xib */,
+				65E3ECA92113448200869DF3 /* TextFieldComponent.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -333,6 +353,10 @@
 				58BA7583201633CC0050D5F1 /* Renderable.swift */,
 				58E98E62201889B900F78BAE /* AnyRenderable.swift */,
 				587A341E2100A09B00B25CCA /* Deletable.swift */,
+				65E3EC9F2113114100869DF3 /* Focusable.swift */,
+				65E3ECAB2113591500869DF3 /* FocusableView.swift */,
+				65E3ECA1211317EA00869DF3 /* FocusCoordinator.swift */,
+				65E3ECA521133C9400869DF3 /* UIKit+CollectionViewFocus.swift */,
 			);
 			path = Renderable;
 			sourceTree = "<group>";
@@ -381,6 +405,9 @@
 				A9509BC2762C8B4277B973D8 /* TableViewAdapter.swift */,
 				5874C80420C9342B004EB5EA /* CollectionViewDataSource.swift */,
 				58D0F12C207F573B00A24E96 /* TableViewAnimation.swift */,
+				65E3ECA321133BF700869DF3 /* FocusEligibilitySource.swift */,
+				65E3ECAD2113594600869DF3 /* BentoCollectionView.swift */,
+				65E3ECAF2113598700869DF3 /* UIKit+BentoCollectionView.swift */,
 			);
 			path = Adapters;
 			sourceTree = "<group>";
@@ -557,8 +584,10 @@
 				5829D26B200FB092001E020D /* ViewController.swift in Sources */,
 				58FC4447207CFBD700DA3614 /* ButtonComponentView.swift in Sources */,
 				58FC4441207CFBD700DA3614 /* MovieComponentView.swift in Sources */,
+				65E3ECA8211340CE00869DF3 /* PersonalDetailsViewController.swift in Sources */,
 				61B40919208523F60063DE25 /* IntroViewModel.swift in Sources */,
 				58FC444D207CFBE200DA3614 /* BookAppointmentViewController.swift in Sources */,
+				65E3ECAA2113448200869DF3 /* TextFieldComponent.swift in Sources */,
 				61B64BB12086561B0092082C /* IntroRenderer.swift in Sources */,
 				58E98E5D2016571F00F78BAE /* ToggleCell.swift in Sources */,
 				58FC4445207CFBD700DA3614 /* LoadingIndicatorView.swift in Sources */,
@@ -578,6 +607,8 @@
 			files = (
 				65496FB8211C323F00511D8A /* TableViewContainerCell.swift in Sources */,
 				65496FB9211C323F00511D8A /* TableViewAdapter.swift in Sources */,
+				65E3ECB02113598700869DF3 /* UIKit+BentoCollectionView.swift in Sources */,
+				65E3ECA02113114100869DF3 /* Focusable.swift in Sources */,
 				58E98E63201889B900F78BAE /* AnyRenderable.swift in Sources */,
 				58BA7586201634120050D5F1 /* Helpers.swift in Sources */,
 				61B64BB420873DA10092082C /* CollectionViewSectionDiff.swift in Sources */,
@@ -586,14 +617,19 @@
 				58BA7584201633CC0050D5F1 /* Renderable.swift in Sources */,
 				5857BECA2056F02C0085EB9C /* If.swift in Sources */,
 				A9509FB12CAD89179FAA03B0 /* Box.swift in Sources */,
+				65E3ECA621133C9400869DF3 /* UIKit+CollectionViewFocus.swift in Sources */,
 				58467B03202B33F200577C77 /* TableViewSectionDiff.swift in Sources */,
 				A9509C4FC3664040FF3649CD /* Node.swift in Sources */,
 				587A341F2100A09B00B25CCA /* Deletable.swift in Sources */,
 				5874C80520C9342B004EB5EA /* CollectionViewDataSource.swift in Sources */,
 				5874C80720C93445004EB5EA /* CollectionViewSupplementaryView.swift in Sources */,
 				61B64BB6208745730092082C /* CollectionViewContainerCell.swift in Sources */,
+				65E3ECA2211317EA00869DF3 /* FocusCoordinator.swift in Sources */,
+				65E3ECAE2113594600869DF3 /* BentoCollectionView.swift in Sources */,
+				65E3ECAC2113591500869DF3 /* FocusableView.swift in Sources */,
 				A9509880661501C40B50E453 /* TableViewHeaderFooterView.swift in Sources */,
 				515F94097C1F82B7E5C2DE0C /* Section.swift in Sources */,
+				65E3ECA421133BF700869DF3 /* FocusEligibilitySource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bento/Adapters/BentoCollectionView.swift
+++ b/Bento/Adapters/BentoCollectionView.swift
@@ -1,0 +1,23 @@
+internal protocol BentoContainerCell {
+    var containedView: UIView? { get }
+}
+
+internal protocol BentoCollectionView: FocusCoordinatorProviding {
+    associatedtype Cell: BentoContainerCell
+    associatedtype DataSource
+
+    var dataSource: DataSource? { get }
+
+    func indexPath(for cell: Cell) -> IndexPath?
+    func visibleCell(at indexPath: IndexPath) -> Cell?
+    func revealCell(at indexPath: IndexPath, animated: Bool)
+}
+
+extension BentoCollectionView {
+    func didRenderBox() {
+        UIApplication.shared.sendAction(#selector(FocusableView.neighboringFocusEligibilityDidChange),
+                                        to: nil,
+                                        from: self,
+                                        for: nil)
+    }
+}

--- a/Bento/Adapters/CollectionViewDataSource.swift
+++ b/Bento/Adapters/CollectionViewDataSource.swift
@@ -2,8 +2,8 @@ import FlexibleDiff
 import UIKit
 
 final class CollectionViewDataSource<SectionId: Hashable, ItemId: Hashable>
-    : NSObject, UICollectionViewDataSource {
-    private var sections: [Section<SectionId, ItemId>] = []
+    : NSObject, UICollectionViewDataSource, FocusEligibilitySourceImplementing {
+    var sections: [Section<SectionId, ItemId>] = []
     private weak var collectionView: UICollectionView?
 
     init(with collectionView: UICollectionView) {

--- a/Bento/Adapters/FocusEligibilitySource.swift
+++ b/Bento/Adapters/FocusEligibilitySource.swift
@@ -1,0 +1,59 @@
+internal protocol FocusEligibilitySource: AnyObject {
+    func indexPathOfFocusableComponent(nextTo indexPath: IndexPath?, direction: FocusSearchDirection, skipsPopulatedComponents: Bool) -> IndexPath?
+}
+
+internal protocol FocusEligibilitySourceImplementing: FocusEligibilitySource {
+    associatedtype SectionId: Hashable
+    associatedtype NodeId: Hashable
+
+    var sections: [Section<SectionId, NodeId>] { get }
+}
+
+extension FocusEligibilitySourceImplementing {
+    func indexPathOfFocusableComponent(nextTo indexPath: IndexPath?, direction: FocusSearchDirection, skipsPopulatedComponents: Bool) -> IndexPath? {
+        let sections = self.sections
+
+        switch direction {
+        case .backward:
+            let indexPath = indexPath ?? IndexPath(item: -1, section: 0)
+            var startNodeIndex = indexPath.item + 1
+
+            for sectionIndex in indexPath.section ..< sections.endIndex {
+                let nodes = sections[sectionIndex].rows
+
+                for nodeIndex in startNodeIndex ..< nodes.endIndex {
+                    if let component = nodes[nodeIndex].component(as: Focusable.self),
+                       component.focusEligibility.isEligible(skipsPopulatedComponents: skipsPopulatedComponents) {
+                        return IndexPath(item: nodeIndex, section: sectionIndex)
+                    }
+                }
+
+                startNodeIndex = 0
+            }
+
+            return nil
+
+        case .forward:
+            let indexPath = indexPath ?? IndexPath(item: sections.last?.rows.endIndex ?? 0,
+                                                   section: max(sections.endIndex - 1, 0))
+            var exclusiveNodeUpperBound = indexPath.item
+
+            for sectionIndex in (sections.startIndex ... indexPath.section).reversed() {
+                let nodes = sections[sectionIndex].rows
+
+                for nodeIndex in (nodes.startIndex ..< exclusiveNodeUpperBound).reversed() {
+                    if let component = nodes[nodeIndex].component(as: Focusable.self),
+                       component.focusEligibility.isEligible(skipsPopulatedComponents: skipsPopulatedComponents) {
+                        return IndexPath(item: nodeIndex, section: sectionIndex)
+                    }
+                }
+
+                exclusiveNodeUpperBound = sectionIndex == sections.startIndex
+                    ? 0
+                    : sections[sectionIndex - 1].rows.endIndex
+            }
+
+            return nil
+        }
+    }
+}

--- a/Bento/Adapters/UIKit+BentoCollectionView.swift
+++ b/Bento/Adapters/UIKit+BentoCollectionView.swift
@@ -1,0 +1,30 @@
+extension UITableView: BentoCollectionView {
+    func indexPath(for cell: TableViewContainerCell) -> IndexPath? {
+        return indexPath(for: cell as UITableViewCell)
+    }
+
+    func visibleCell(at indexPath: IndexPath) -> TableViewContainerCell? {
+        return cellForRow(at: indexPath) as? TableViewContainerCell
+    }
+
+    func revealCell(at indexPath: IndexPath, animated: Bool) {
+        scrollToRow(at: indexPath, at: .bottom, animated: false)
+    }
+}
+
+extension UICollectionView: BentoCollectionView {
+    func indexPath(for cell: CollectionViewContainerCell) -> IndexPath? {
+        return indexPath(for: cell)
+    }
+
+    func visibleCell(at indexPath: IndexPath) -> CollectionViewContainerCell? {
+        return cellForItem(at: indexPath) as? CollectionViewContainerCell
+    }
+
+    func revealCell(at indexPath: IndexPath, animated: Bool) {
+        scrollToItem(at: indexPath, at: .bottom, animated: animated)
+    }
+}
+
+extension TableViewContainerCell: BentoContainerCell {}
+extension CollectionViewContainerCell: BentoContainerCell {}

--- a/Bento/Bento/Box.swift
+++ b/Bento/Bento/Box.swift
@@ -42,10 +42,12 @@ extension UICollectionView {
     public func render<SectionId, ItemId>(_ box: Box<SectionId, ItemId>, completion: (() -> Void)? = nil) {
         let adapter: CollectionViewDataSource<SectionId, ItemId> = getAdapter()
         adapter.update(sections: box.sections, completion: completion)
+        didRenderBox()
     }
 
     public func render<SectionId, ItemId>(_ box: Box<SectionId, ItemId>, animated: Bool) {
         let adapter: CollectionViewDataSource<SectionId, ItemId> = getAdapter()
         adapter.update(sections: box.sections, animated: animated)
+        didRenderBox()
     }
 }

--- a/Bento/Bento/Node.swift
+++ b/Bento/Bento/Node.swift
@@ -13,10 +13,6 @@ public struct Node<Identifier: Hashable>: Equatable {
         self.init(id: id, component: AnyRenderable(component))
     }
 
-    public init<R: Deletable>(id: Identifier, component: R) where R.View: UIView {
-        self.init(id: id, component: AnyRenderable(component))
-    }
-
     public static func == (lhs: Node, rhs: Node) -> Bool {
         return lhs.id == rhs.id && lhs.component == rhs.component
     }
@@ -39,10 +35,6 @@ public struct Node<Identifier: Hashable>: Equatable {
 }
 
 public func <> <RowId, R: Renderable>(id: RowId, component: R) -> Node<RowId> where R.View: UIView {
-    return Node(id: id, component: component)
-}
-
-public func <> <RowId, R: Deletable>(id: RowId, component: R) -> Node<RowId> where R.View: UIView {
     return Node(id: id, component: component)
 }
 

--- a/Bento/Bento/UITableViewExtensions.swift
+++ b/Bento/Bento/UITableViewExtensions.swift
@@ -20,8 +20,7 @@ extension UITableView {
     }
 
     public func render<SectionId, RowId>(_ box: Box<SectionId, RowId>) {
-        let adapter: TableViewAdapterBase<SectionId, RowId> = getAdapter()
-        adapter.update(sections: box.sections, with: TableViewAnimation())
+        render(box, animated: true)
     }
 
     public func render<SectionId, RowId>(_ box: Box<SectionId, RowId>, animated: Bool) {
@@ -31,12 +30,14 @@ extension UITableView {
         } else {
             adapter.update(sections: box.sections)
         }
+        didRenderBox()
     }
 
     public func render<SectionId, RowId>(_ box: Box<SectionId, RowId>, with animation: TableViewAnimation) {
         let adapter: TableViewAdapterBase<SectionId, RowId> = getAdapter()
 
         adapter.update(sections: box.sections, with: animation)
+        didRenderBox()
     }
 
     private struct AssociatedKey {

--- a/Bento/Helpers.swift
+++ b/Bento/Helpers.swift
@@ -49,3 +49,11 @@ extension Optional {
         return selector(unwrapped, other)
     }
 }
+
+internal func search<T>(from leaf: UIView, type: T.Type) -> T? {
+    var cell = leaf.superview
+    while let view = cell, !(view is T) {
+        cell = view.superview
+    }
+    return cell as! T?
+}

--- a/Bento/Renderable/AnyRenderable.swift
+++ b/Bento/Renderable/AnyRenderable.swift
@@ -1,14 +1,6 @@
 import UIKit
 
-struct AnyRenderable: Renderable, Deletable {
-    var canBeDeleted: Bool {
-        return base.canBeDeleted
-    }
-
-    var deleteActionText: String {
-        return base.deleteActionText
-    }
-
+struct AnyRenderable: Renderable {
     var reuseIdentifier: String {
         return base.reuseIdentifier
     }
@@ -17,10 +9,6 @@ struct AnyRenderable: Renderable, Deletable {
 
     init<Base: Renderable>(_ base: Base) where Base.View: UIView {
         self.base = AnyRenderableBox(base)
-    }
-
-    init<Base: Deletable>(_ base: Base) where Base.View: UIView {
-        self.base = AnyDeletableBox(base)
     }
 
     func generate() -> UIView {
@@ -67,30 +55,8 @@ struct AnyRenderable: Renderable, Deletable {
         return view
     }
 
-    func delete() {
-        base.delete()
-    }
-
     static func ==(lhs: AnyRenderable, rhs: AnyRenderable) -> Bool {
         return lhs.base.equals(to: rhs.base)
-    }
-}
-
-private class AnyDeletableBox<Base: Deletable>: AnyRenderableBox<Base> where Base.View: UIView {
-    override var canBeDeleted: Bool {
-        return base.canBeDeleted
-    }
-
-    override var deleteActionText: String {
-        return base.deleteActionText
-    }
-
-    override init(_ base: Base) {
-        super.init(base)
-    }
-
-    override func delete() {
-        base.delete()
     }
 }
 
@@ -126,14 +92,6 @@ private class AnyRenderableBox<Base: Renderable>: AnyRenderableBoxBase where Bas
 }
 
 private class AnyRenderableBoxBase {
-    var canBeDeleted: Bool {
-        return false
-    }
-
-    var deleteActionText: String {
-        return ""
-    }
-
     var reuseIdentifier: String { fatalError() }
 
     init() {}
@@ -142,5 +100,4 @@ private class AnyRenderableBoxBase {
     func generate() -> UIView { fatalError() }
     func equals(to other: AnyRenderableBoxBase) -> Bool { fatalError() }
     func cast<T>(to type: T.Type) -> T? { fatalError() }
-    func delete() {}
 }

--- a/Bento/Renderable/Deletable.swift
+++ b/Bento/Renderable/Deletable.swift
@@ -1,10 +1,8 @@
 import UIKit
 
-public protocol Deletable: Renderable {
+public protocol Deletable {
     var canBeDeleted: Bool { get }
-
     var deleteActionText: String { get }
-
     var backgroundColor: UIColor? { get }
 
     func delete()

--- a/Bento/Renderable/FocusCoordinator.swift
+++ b/Bento/Renderable/FocusCoordinator.swift
@@ -1,0 +1,95 @@
+/// `FocusCoordinating` provides coordination of components to yield
+/// first responder status, and insights of its relative position among all
+/// first responder eligible components.
+public protocol FocusCoordinating {
+    /// Whether the focus can be moved towards the specified direction.
+    func canMove(_ direction: FocusSearchDirection) -> Bool
+
+    /// Notify the coordinator that the component intends to yield its focus to
+    /// any focusable component in the specified direction. You call this method
+    /// when your component is about to resign from being the first responder.
+    ///
+    /// - returns: `true` if the coordinator has taken over the first responder
+    ///            status. `false` if the component should proceed to resign
+    ///            from being the first responder as usual.
+    func move(_ direction: FocusSearchDirection) -> Bool
+}
+
+public enum FocusSearchDirection {
+    /// The focus should move towards the beginning of the component tree.
+    case forward
+
+    /// The focus should move towards the end of the component tree.
+    case backward
+}
+
+public struct DefaultFocusCoordinator: FocusCoordinating {
+    public func canMove(_ direction: FocusSearchDirection) -> Bool {
+        return false
+    }
+
+    public func move(_ direction: FocusSearchDirection) -> Bool {
+        return false
+    }
+}
+
+private struct FocusCoordinator<Container: BentoCollectionView>: FocusCoordinating {
+    func canMove(_ direction: FocusSearchDirection) -> Bool {
+        return source.indexPathOfFocusableComponent(nextTo: indexPath, direction: direction, skipsPopulatedComponents: false) != nil
+    }
+
+    func move(_ direction: FocusSearchDirection) -> Bool {
+        return container.focusItem(nextTo: indexPath, direction: direction, skipsPopulatedComponents: false)
+    }
+
+    private let container: Container
+    private let indexPath: IndexPath
+    private let source: FocusEligibilitySource
+
+    fileprivate init(container: Container, indexPath: IndexPath, source: FocusEligibilitySource) {
+        self.container = container
+        self.indexPath = indexPath
+        self.source = source
+    }
+}
+
+extension BentoCollectionView {
+    func focusCoordinator(for view: UIView) -> FocusCoordinating? {
+        if let cell = search(from: view, type: Cell.self),
+            let indexPath = indexPath(for: cell),
+            let source = dataSource as? FocusEligibilitySource {
+            return FocusCoordinator(container: self, indexPath: indexPath, source: source)
+        }
+        return nil
+    }
+
+    @discardableResult
+    func focusItem(nextTo indexPath: IndexPath?, direction: FocusSearchDirection, skipsPopulatedComponents: Bool, animated: Bool = false) -> Bool {
+        let indexPath = (dataSource as? FocusEligibilitySource)?
+            .indexPathOfFocusableComponent(
+                nextTo: indexPath,
+                direction: direction,
+                skipsPopulatedComponents: skipsPopulatedComponents
+            )
+
+        if let indexPath = indexPath {
+            func focus() -> Bool {
+                if let visibleCell = visibleCell(at: indexPath) {
+                    (visibleCell.containedView as? FocusableView)?.focus()
+                    return true
+                }
+                return false
+            }
+
+            if focus() {
+                return true
+            } else {
+                revealCell(at: indexPath, animated: animated)
+                let hasTransferred = focus()
+                return hasTransferred
+            }
+        }
+
+        return false
+    }
+}

--- a/Bento/Renderable/Focusable.swift
+++ b/Bento/Renderable/Focusable.swift
@@ -1,0 +1,45 @@
+/// Represent a component that can be focused (assume first responder) and
+/// participates in Bento focus coordination.
+///
+/// - important: Your component root view should conform to `FocusableView`.
+public protocol Focusable {
+    /// Declare whether the component is eligible for focus.
+    var focusEligibility: FocusEligibility { get }
+}
+
+public enum FocusEligibility: Equatable {
+    /// The component is not eligible for focus.
+    ///
+    /// For example, the component is focusable but is currently disabled.
+    case ineligible
+
+    /// The component is eligible for focus.
+    ///
+    /// The focus search utilizes the specified content status to filter out
+    /// components, should the user request to skip over components already
+    /// populated with content.
+    case eligible(ContentStatus)
+
+    public enum ContentStatus: Equatable {
+        /// The component has been populated with content.
+        case populated
+
+        /// The component does not have any content.
+        case empty
+
+        public static var `default`: ContentStatus {
+            return .empty
+        }
+    }
+
+    internal func isEligible(skipsPopulatedComponents: Bool) -> Bool {
+        switch self {
+        case .ineligible:
+            return false
+        case .eligible(.populated):
+            return !skipsPopulatedComponents
+        case .eligible(.empty):
+            return true
+        }
+    }
+}

--- a/Bento/Renderable/FocusableView.swift
+++ b/Bento/Renderable/FocusableView.swift
@@ -1,0 +1,40 @@
+/// Represent the root view of a `Focusable` component.
+@objc(BentoFocusableView)
+public protocol FocusableView: AnyObject {
+    /// Assume focus.
+    ///
+    /// Root views of `Focusable` components must implement this method to
+    /// respond to the focus request from the focus coordination.
+    @objc(bento_focus)
+    func focus()
+
+    /// Signify the focus eligibility of neighboring components might have
+    /// changed.
+    ///
+    /// If you implement controls that depend on focus eligibility status* of
+    /// neighboring components e.g. return key, and back/forward buttons as
+    /// input accessories, you should implement this method to be notified when
+    /// these statuses might have changed and invalidated the state of your
+    /// controls.
+    ///
+    /// \* queried via `FocusCoordinating.canMove(_:)`.
+    @objc(bento_neighboringFocusEligibilityDidChange)
+    optional func neighboringFocusEligibilityDidChange()
+}
+
+extension FocusableView where Self: UIView {
+    /// The focus coordinator of this view.
+    ///
+    /// - warning: The focus coordinator should not escape the closure scope.
+    ///            The behavior is undefined if you retain the coordinator.
+    public func withFocusCoordinator<Result>(_ action: (FocusCoordinating) -> Result) -> Result {
+        let coordinator = search(from: self, type: FocusCoordinatorProviding.self)?
+            .focusCoordinator(for: self)
+            ?? DefaultFocusCoordinator()
+        return action(coordinator)
+    }
+}
+
+internal protocol FocusCoordinatorProviding: AnyObject {
+    func focusCoordinator(for view: UIView) -> FocusCoordinating?
+}

--- a/Bento/Renderable/UIKit+CollectionViewFocus.swift
+++ b/Bento/Renderable/UIKit+CollectionViewFocus.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+extension UITableView {
+    public func focus(direction: FocusSearchDirection = .backward, skipsPopulatedComponents: Bool = true, animated: Bool = true) {
+        focusItem(nextTo: nil,
+                  direction: direction,
+                  skipsPopulatedComponents: skipsPopulatedComponents,
+                  animated: animated)
+    }
+}
+
+extension UICollectionView {
+    public func focus(direction: FocusSearchDirection = .backward, skipsPopulatedComponents: Bool = true, animated: Bool = true) {
+        focusItem(nextTo: nil,
+                  direction: direction,
+                  skipsPopulatedComponents: skipsPopulatedComponents,
+                  animated: animated)
+    }
+}

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1vi-kq-Q67">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1vi-kq-Q67">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -88,6 +88,7 @@
                         <segue destination="Oya-eA-AAR" kind="relationship" relationship="viewControllers" id="LZH-43-MBN"/>
                         <segue destination="PRy-Vb-AeU" kind="relationship" relationship="viewControllers" id="wEh-Q6-b9y"/>
                         <segue destination="A84-rP-dBm" kind="relationship" relationship="viewControllers" id="kc6-x5-QYg"/>
+                        <segue destination="chK-qj-BUB" kind="relationship" relationship="viewControllers" id="wPL-ab-eW5"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zmd-KD-IGq" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -124,6 +125,37 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="G1c-W3-cMi" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-332" y="-710"/>
+        </scene>
+        <!--Personal Details-->
+        <scene sceneID="cfo-gg-mi0">
+            <objects>
+                <viewController id="chK-qj-BUB" userLabel="Personal Details" customClass="PersonalDetailsViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="XWc-12-3bO">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="c1j-cj-vBB">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="c1j-cj-vBB" firstAttribute="top" secondItem="XWc-12-3bO" secondAttribute="top" id="3Rz-wU-4hX"/>
+                            <constraint firstAttribute="trailing" secondItem="c1j-cj-vBB" secondAttribute="trailing" id="8gi-QZ-qJf"/>
+                            <constraint firstItem="c1j-cj-vBB" firstAttribute="leading" secondItem="XWc-12-3bO" secondAttribute="leading" id="D0c-IC-kO3"/>
+                            <constraint firstAttribute="bottom" secondItem="c1j-cj-vBB" secondAttribute="bottom" id="QN1-u8-KBa"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="ISD-Gh-Pj3"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Me" id="oMI-6K-ZOY"/>
+                    <connections>
+                        <outlet property="tableView" destination="c1j-cj-vBB" id="YbO-CM-yTi"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="M0J-jI-zTk" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-332" y="-1401.049475262369"/>
         </scene>
         <!--Intro View Controller-->
         <scene sceneID="XZ1-7F-rgR">

--- a/Example/Cells/MovieComponentView.swift
+++ b/Example/Cells/MovieComponentView.swift
@@ -2,7 +2,7 @@ import UIKit
 import Bento
 import Kingfisher
 
-final class MovieComponent: Deletable {
+final class MovieComponent: Renderable, Deletable {
     private let movie: Movie
     private let didDelete: (() -> Void)?
 

--- a/Example/Cells/TextFieldComponent.swift
+++ b/Example/Cells/TextFieldComponent.swift
@@ -1,0 +1,172 @@
+import UIKit
+import Bento
+
+final class TextFieldComponent: NSObject, Renderable, Focusable {
+    let title: String
+    let text: String
+    let didUpdate: (String) -> Void
+    var focusEligibility: FocusEligibility {
+        return text.isEmpty ? .eligible(.empty) : .eligible(.populated)
+    }
+
+    init(title: String, text: String, didUpdate: @escaping (String) -> Void) {
+        self.title = title
+        self.text = text
+        self.didUpdate = didUpdate
+    }
+
+    func render(in view: View) {
+        view.titleLabel.text = title
+        view.textField.text = text
+        view.didUpdate = didUpdate
+    }
+
+    class View: UIStackView {
+        let titleLabel: UILabel
+        let textField: UITextField
+        var didUpdate: ((String) -> Void)?
+
+        init() {
+            titleLabel = UILabel()
+            textField = UITextField()
+
+            super.init(frame: .zero)
+
+            preservesSuperviewLayoutMargins = true
+            isLayoutMarginsRelativeArrangement = true
+
+            addArrangedSubview(titleLabel)
+            addArrangedSubview(textField)
+
+            axis = .horizontal
+            distribution = .fill
+            alignment = .center
+
+            let constraint = titleLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.3)
+            constraint.priority = .defaultHigh
+            constraint.isActive = true
+
+            let constraint2 = heightAnchor.constraint(greaterThanOrEqualToConstant: 44.0)
+            constraint2.priority = .defaultHigh
+            constraint2.isActive = true
+
+            textField.delegate = self
+            textField.inputAccessoryView = FocusToolbar(view: self)
+            textField.addTarget(self, action: #selector(self.textFieldDidChange), for: .editingChanged)
+        }
+
+        @available(*, unavailable)
+        required init(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
+}
+
+extension TextFieldComponent.View: FocusableView {
+    public func focus() {
+        textField.becomeFirstResponder()
+    }
+
+    public func neighboringFocusEligibilityDidChange() {
+        (textField.inputAccessoryView as? FocusToolbar)?.updateAvailability()
+        updateReturnKeyType()
+        textField.reloadInputViews()
+    }
+}
+
+extension TextFieldComponent.View: UITextFieldDelegate {
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        updateReturnKeyType()
+        return true
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        withFocusCoordinator { coordinator in
+            if !coordinator.move(.backward) {
+                // The coordinator has not done anything regarding the first
+                // responder status. Proceed to resign the first responder
+                // status as expected.
+                textField.resignFirstResponder()
+            }
+        }
+
+        return false
+    }
+
+    @objc private func textFieldDidChange(_ textField: UITextField) {
+        didUpdate?(textField.text ?? "")
+    }
+
+    private func updateReturnKeyType() {
+        withFocusCoordinator { coordinator in
+            textField.returnKeyType = coordinator.canMove(.backward)
+                ? .next
+                : .done
+        }
+    }
+}
+
+final class FocusToolbar: UIToolbar {
+    weak var view: (UIView & FocusableView)?
+    var backwardButton: UIBarButtonItem!
+    var forwardButton: UIBarButtonItem!
+
+    init(view: UIView & FocusableView) {
+        self.view = view
+
+        super.init(frame: .zero)
+
+        backwardButton = UIBarButtonItem(barButtonSystemItem: .fastForward, target: self, action: #selector(moveBackward))
+        forwardButton = UIBarButtonItem(barButtonSystemItem: .rewind, target: self, action: #selector(moveForward))
+
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let items = [
+            forwardButton!,
+            backwardButton!,
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismiss))
+        ]
+        setItems(items, animated: false)
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func willMove(toSuperview newSuperview: UIView?) {
+        guard newSuperview != nil else { return }
+        updateAvailability()
+    }
+
+    fileprivate func updateAvailability() {
+        view?.withFocusCoordinator { coordinator in
+            backwardButton.isEnabled = coordinator.canMove(.backward)
+            forwardButton.isEnabled = coordinator.canMove(.forward)
+        }
+    }
+
+    @objc private func moveBackward() {
+        view?.withFocusCoordinator { coordinator in
+            _ = coordinator.move(.backward)
+        }
+    }
+
+    @objc private func moveForward() {
+        view?.withFocusCoordinator { coordinator in
+            _ = coordinator.move(.forward)
+        }
+    }
+
+    @objc private func dismiss() {
+        view?.endEditing(true)
+    }
+}
+
+extension UIBarButtonItem {
+    func settingEnabled(_ isEnabled: Bool) -> Self {
+        self.isEnabled = isEnabled
+        return self
+    }
+}

--- a/Example/PersonalDetailsViewController.swift
+++ b/Example/PersonalDetailsViewController.swift
@@ -1,0 +1,176 @@
+import UIKit
+import Bento
+import ReactiveSwift
+import ReactiveFeedback
+import enum Result.NoError
+
+final class PersonalDetailsViewController: UIViewController {
+    @IBOutlet weak var tableView: UITableView!
+
+    lazy var viewModel = PersonalDetailsViewModel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTableView()
+
+        let renderer = PersonalDetailsRenderer()
+
+        viewModel.state
+            .producer
+            .map { [weak viewModel] state in
+                return renderer.render(state, action: { viewModel?.send($0) })
+            }
+            .startWithValues(tableView.render)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        tableView.focus(animated: animated)
+    }
+
+    private func setupTableView() {
+        tableView.estimatedSectionFooterHeight = 18
+        tableView.estimatedSectionHeaderHeight = 18
+        tableView.sectionHeaderHeight = UITableViewAutomaticDimension
+        tableView.sectionFooterHeight = UITableViewAutomaticDimension
+        tableView.keyboardDismissMode = .interactive
+    }
+}
+
+final class PersonalDetailsViewModel {
+    let state: Property<State>
+    private let userActionObserver: Signal<UserAction, NoError>.Observer
+
+    init() {
+        let (userActions, userActionObserver) = Signal<UserAction, NoError>.pipe()
+        self.state = Property(
+            initial: State(),
+            reduce: PersonalDetailsViewModel.reduce,
+            feedbacks: [
+                PersonalDetailsViewModel.feedback(userActions)
+            ]
+        )
+        self.userActionObserver = userActionObserver
+    }
+
+    func send(_ action: UserAction) {
+        userActionObserver.send(value: action)
+    }
+
+    struct State {
+        var firstName: String = ""
+        var lastName: String = ""
+        var placeOfBirth: String = ""
+        var email: String = ""
+        var code: String = ""
+        var showMore = false
+    }
+
+    enum UserAction {
+        case update(StateUpdate)
+
+        struct StateUpdate {
+            fileprivate let apply: (inout State) -> Void
+
+            init<U>(_ keyPath: WritableKeyPath<State, U>, _ value: U) {
+                apply = { $0[keyPath: keyPath] = value }
+            }
+        }
+    }
+
+    enum Event {
+        case ui(UserAction)
+    }
+
+    private static func reduce(state: State, event: Event) -> State {
+        switch event {
+        case let .ui(.update(update)):
+            var state = state
+            update.apply(&state)
+            return state
+        }
+    }
+
+    private static func feedback(_ userActions: Signal<UserAction, NoError>) -> Feedback<State, Event> {
+        return Feedback { scheduler, _ in
+            return userActions.map(Event.ui).observe(on: scheduler)
+        }
+    }
+}
+
+struct PersonalDetailsRenderer {
+    enum SectionId {
+        case details
+        case account
+    }
+
+    enum NodeId {
+        case firstName
+        case lastName
+        case placeOfBirth
+        case email
+        case code
+        case more
+    }
+
+    init() {}
+
+    func render(_ state: PersonalDetailsViewModel.State, action: @escaping (PersonalDetailsViewModel.UserAction) -> Void) -> Box<SectionId, NodeId> {
+        return Box.empty
+            |-+ Section(id: .details)
+            |---+ Node(
+                id: .more,
+                component: ToggleComponent(
+                    isOn: state.showMore,
+                    title: "Show Detailed Form",
+                    onToggle: { action(.update(.init(\.showMore, $0))) }
+                )
+            )
+            |---+ Node(
+                id: .firstName,
+                component: TextFieldComponent(
+                    title: "First Name",
+                    text: state.firstName,
+                    didUpdate: { action(.update(.init(\.firstName, $0))) }
+                )
+            )
+            |---+ Node(
+                id: .lastName,
+                component: TextFieldComponent(
+                    title: "Last Name",
+                    text: state.lastName,
+                    didUpdate: { action(.update(.init(\.lastName, $0))) }
+                )
+            )
+            |---+ Node(
+                id: .placeOfBirth,
+                component: TextFieldComponent(
+                    title: "Place of Birth",
+                    text: state.placeOfBirth,
+                    didUpdate: { action(.update(.init(\.placeOfBirth, $0))) }
+                )
+            )
+            |-+ Section(id: .account)
+            |---? .iff(state.showMore) {
+                return [
+                    Node(
+                        id: .email,
+                        component: TextFieldComponent(
+                            title: "Email",
+                            text: state.email,
+                            didUpdate: { action(.update(.init(\.email, $0))) }
+                        )
+                    ),
+                    Node(
+                        id: .code,
+                        component: TextFieldComponent(
+                            title: "Code",
+                            text: state.code,
+                            didUpdate: { action(.update(.init(\.code, $0))) }
+                        )
+                    )
+                ]
+            }
+    }
+}


### PR DESCRIPTION
This PR provides an infrastructure of focus coordination among Bento components.

### Creating a focusable component
For a Bento component to participate in the focus coordination, it would need to:

1. Conform to `Focusable`.

    Components may specify whether they participate in the focus coordination via `canBeFocused`. This is important for the focus coordination to discover all focusable components, especially those that are off screen.

2. Have its view conforming to `FocusableView`.

    The focus coordination invokes `focus()` on the conforming component root view when appropriate. The root view should respond [by asking the appropriate subviews (or itself) to assume the first responder status](https://github.com/Babylonpartners/Bento/blob/f00daad852eb02af7ecaa4a9d73815929da1e0f0/Example/Cells/TextFieldComponent.swift#L63).

    Conforming root views would automatically gain `withFocusCoordinator(_:)`, which provides scoped access to the focus coordination mechanism. The coordinator can be used to:

    a. [attempt to pass on its first responder status via `move(_:)`](https://github.com/Babylonpartners/Bento/blob/f00daad852eb02af7ecaa4a9d73815929da1e0f0/Example/Cells/TextFieldComponent.swift#L80); or

    b. [query whether there is any focusable component following it via `canMove(_:)`, so as to adjust the keyboard return key type, for example](https://github.com/Babylonpartners/Bento/blob/f00daad852eb02af7ecaa4a9d73815929da1e0f0/Example/Cells/TextFieldComponent.swift#L69).

3. Optionally be notified when a new 🍱 has been rendered.

    For example, if you have a input accessory toolbar with buttons to navigate between form fields, the availability of the buttons might be invalidated by new 🍱 boxes & therefore need to be updated. One may implement `neighbouringFocusEligibilityDidChange()` to receive such messages.

### Focus without user interaction

Bento introduces `focus(animated:)` to `UITableView` and `UICollectionView`, which upon invocation would scroll to the first focusable component & ask it to focus.

### Example: A personal details form.
Available as the fifth tab in the Bento example app. Check `PersonalDetailsViewController.swift` for the source.

![](https://user-images.githubusercontent.com/11806295/43709534-0580369c-9965-11e8-8b8e-c127fbd26779.gif)

### Implementation Note

This is architecturally the same as the focus control in our pre-Bento infrastructure. The notable difference is the implementation being extended to support both kind of collection views.

`FocusCoordinating` is a transient view of the abstract focus coordination mechanism.

It is exposed as a scoped accessor `withFocusCoordinator(_:)` to discourage escaping/retaining the coordinator. Prior Art: `withoutActuallyEscaping(_:)`.

Bento component views have zero knowledge about its position within the collection view. So for the purpose of focus coordination we need to query it & have it stored temporarily, but the info should be discarded as soon as we are done with the coordination.

The implementations introduce a group of internal protocols, centred by `BentoCollectionView`. `BentoContainerView` defines a set of requirements that is necessary for focus coordination (implemented as an extension to `BentoCollectionView`). Auxiliary protocols are introduced to either provide stronger constraints for container-agnostic implementations, or have a subset that can be used as existentials (protocol types) in dynamic type casting.