### PR TITLE
Support per component height estimation & height calculation.

### DIFF
--- a/Bento/Adapters/SectionedFormAdapter.swift
+++ b/Bento/Adapters/SectionedFormAdapter.swift
@@ -54,6 +54,8 @@ final class SectionedFormAdapter<SectionId: Hashable, RowId: Hashable>
             componentView = component.generate()
             cell.install(view: componentView)
         }
+
+        copyLayoutMargins(from: tableView, to: cell.contentView)
         component.render(in: componentView)
         return cell
 
@@ -74,11 +76,53 @@ final class SectionedFormAdapter<SectionId: Hashable, RowId: Hashable>
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return sections[section].header == nil ? CGFloat.leastNonzeroMagnitude : UITableViewAutomaticDimension
+        if let component = sections[section].header {
+            return component.height(forWidth: tableView.bounds.width,
+                                    inheritedMargins: HorizontalEdgeInsets(tableView.layoutMargins))
+                ?? tableView.sectionHeaderHeight
+        }
+        return CGFloat.leastNonzeroMagnitude
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return sections[section].footer == nil ? CGFloat.leastNonzeroMagnitude : UITableViewAutomaticDimension
+        if let component = sections[section].footer {
+            return component.height(forWidth: tableView.bounds.width,
+                                    inheritedMargins: HorizontalEdgeInsets(tableView.layoutMargins))
+                ?? tableView.sectionFooterHeight
+        }
+        return CGFloat.leastNonzeroMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let component = sections[indexPath.section].rows[indexPath.row].component
+        return component.height(forWidth: tableView.bounds.width,
+                                inheritedMargins: HorizontalEdgeInsets(tableView.layoutMargins))
+            ?? tableView.rowHeight
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        if let component = sections[section].header {
+            return component.estimatedHeight(forWidth: tableView.bounds.width,
+                                             inheritedMargins: HorizontalEdgeInsets(tableView.layoutMargins))
+                ?? tableView.estimatedSectionHeaderHeight
+        }
+        return CGFloat.leastNonzeroMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
+        if let component = sections[section].footer {
+            return component.estimatedHeight(forWidth: tableView.bounds.width,
+                                             inheritedMargins: HorizontalEdgeInsets(tableView.layoutMargins))
+                ?? tableView.estimatedSectionFooterHeight
+        }
+        return CGFloat.leastNonzeroMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        let component = sections[indexPath.section].rows[indexPath.row].component
+        return component.estimatedHeight(forWidth: tableView.bounds.width,
+                                         inheritedMargins: HorizontalEdgeInsets(tableView.layoutMargins))
+            ?? tableView.estimatedRowHeight
     }
 
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
@@ -108,6 +152,13 @@ final class SectionedFormAdapter<SectionId: Hashable, RowId: Hashable>
         return UISwipeActionsConfiguration(actions: [action])
     }
 
+    private func copyLayoutMargins(from tableView: UITableView, to view: UIView) {
+        view.layoutMargins = UIEdgeInsets(top: 0,
+                                          left: tableView.layoutMargins.left,
+                                          bottom: 0,
+                                          right: tableView.layoutMargins.right)
+    }
+
     private func deleteRow(at indexPath: IndexPath, actionPerformed: ((Bool) -> Void)?) {
         let row = sections[indexPath.section].rows[indexPath.row]
         row.component.delete()
@@ -132,6 +183,8 @@ final class SectionedFormAdapter<SectionId: Hashable, RowId: Hashable>
             componentView = node.generate()
             header.install(view: componentView)
         }
+
+        copyLayoutMargins(from: tableView, to: header.contentView)
         node.render(in: componentView)
         return header
     }

--- a/Bento/Adapters/SectionedFormAdapter.swift
+++ b/Bento/Adapters/SectionedFormAdapter.swift
@@ -97,6 +97,7 @@ final class SectionedFormAdapter<SectionId: Hashable, RowId: Hashable>
         let component = sections[indexPath.section].rows[indexPath.row].component
         return component.height(forWidth: tableView.bounds.width,
                                 inheritedMargins: HorizontalEdgeInsets(tableView.layoutMargins))
+            .map { $0 + tableView.separatorHeightOffset }
             ?? tableView.rowHeight
     }
 
@@ -122,6 +123,7 @@ final class SectionedFormAdapter<SectionId: Hashable, RowId: Hashable>
         let component = sections[indexPath.section].rows[indexPath.row].component
         return component.estimatedHeight(forWidth: tableView.bounds.width,
                                          inheritedMargins: HorizontalEdgeInsets(tableView.layoutMargins))
+            .map { $0 + tableView.separatorHeightOffset }
             ?? tableView.estimatedRowHeight
     }
 
@@ -187,5 +189,14 @@ final class SectionedFormAdapter<SectionId: Hashable, RowId: Hashable>
         copyLayoutMargins(from: tableView, to: header.contentView)
         node.render(in: componentView)
         return header
+    }
+}
+
+extension UITableView {
+    fileprivate var separatorHeightOffset: CGFloat {
+        // The UITableView separator is one pixel high.
+        return separatorStyle == .none
+            ? 0.0
+            : (1.0 / contentScaleFactor)
     }
 }

--- a/Bento/Bento/Node.swift
+++ b/Bento/Bento/Node.swift
@@ -21,16 +21,16 @@ public struct Node<Identifier: Hashable>: Equatable {
         return lhs.id == rhs.id && lhs.component == rhs.component
     }
 
-    public func sizeBoundTo(width: CGFloat) -> CGSize {
-        return component.sizeBoundTo(width: width)
+    public func sizeBoundTo(width: CGFloat, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return component.sizeBoundTo(width: width, inheritedMargins: inheritedMargins)
     }
 
-    public func sizeBoundTo(height: CGFloat) -> CGSize {
-        return component.sizeBoundTo(height: height)
+    public func sizeBoundTo(height: CGFloat, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return component.sizeBoundTo(height: height, inheritedMargins: inheritedMargins)
     }
 
-    public func sizeBoundTo(size: CGSize) -> CGSize {
-        return component.sizeBoundTo(size: size)
+    public func sizeBoundTo(size: CGSize, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return component.sizeBoundTo(size: size, inheritedMargins: inheritedMargins)
     }
 }
 

--- a/Bento/Bento/Section.swift
+++ b/Bento/Bento/Section.swift
@@ -53,28 +53,28 @@ public struct Section<SectionId: Hashable, RowId: Hashable>: Equatable {
         self.rows = rows
     }
 
-    public func headerSizeBoundTo(width: CGFloat) -> CGSize {
-        return header?.sizeBoundTo(width: width) ?? .zero
+    public func headerSizeBoundTo(width: CGFloat, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return header?.sizeBoundTo(width: width, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func headerSizeBoundTo(height: CGFloat) -> CGSize {
-        return header?.sizeBoundTo(height: height) ?? .zero
+    public func headerSizeBoundTo(height: CGFloat, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return header?.sizeBoundTo(height: height, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func headerSizeBoundTo(size: CGSize) -> CGSize {
-        return header?.sizeBoundTo(size: size) ?? .zero
+    public func headerSizeBoundTo(size: CGSize, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return header?.sizeBoundTo(size: size, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func footerSizeBoundTo(width: CGFloat) -> CGSize {
-        return footer?.sizeBoundTo(width: width) ?? .zero
+    public func footerSizeBoundTo(width: CGFloat, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return footer?.sizeBoundTo(width: width, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func footerSizeBoundTo(height: CGFloat) -> CGSize {
-        return footer?.sizeBoundTo(height: height) ?? .zero
+    public func footerSizeBoundTo(height: CGFloat, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return footer?.sizeBoundTo(height: height, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func footerSizeBoundTo(size: CGSize) -> CGSize {
-        return footer?.sizeBoundTo(size: size) ?? .zero
+    public func footerSizeBoundTo(size: CGSize, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return footer?.sizeBoundTo(size: size, inheritedMargins: inheritedMargins) ?? .zero
     }
 
     public static func hasEqualMetadata(_ lhs: Section, _ rhs: Section) -> Bool {

--- a/Bento/Renderable/AnyRenderable.swift
+++ b/Bento/Renderable/AnyRenderable.swift
@@ -31,30 +31,12 @@ struct AnyRenderable: Renderable, Deletable {
         base.render(in: view)
     }
 
-    func sizeBoundTo(width: CGFloat) -> CGSize {
-        return rendered()
-            .systemLayoutSizeFitting(CGSize(width: width, height: UILayoutFittingCompressedSize.height),
-                                                      withHorizontalFittingPriority: .required,
-                                                      verticalFittingPriority: .defaultLow)
+    func height(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat? {
+        return base.height(forWidth: width, inheritedMargins: inheritedMargins)
     }
 
-    func sizeBoundTo(height: CGFloat) -> CGSize {
-        return rendered()
-            .systemLayoutSizeFitting(CGSize(width: UILayoutFittingCompressedSize.width, height: height),
-                                     withHorizontalFittingPriority: .defaultLow,
-                                     verticalFittingPriority: .required)
-    }
-
-    func sizeBoundTo(size: CGSize) -> CGSize {
-        return rendered()
-            .systemLayoutSizeFitting(size)
-    }
-
-    private func rendered() -> UIView {
-        let view = generate()
-        render(in: view)
-
-        return view
+    func estimatedHeight(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat? {
+        return base.estimatedHeight(forWidth: width, inheritedMargins: inheritedMargins)
     }
 
     func delete() {
@@ -104,6 +86,14 @@ private class AnyRenderableBox<Base: Renderable>: AnyRenderableBoxBase where Bas
         return base.generate()
     }
 
+    override func height(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat? {
+        return base.height(forWidth: width, inheritedMargins: inheritedMargins)
+    }
+
+    override func estimatedHeight(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat? {
+        return base.estimatedHeight(forWidth: width, inheritedMargins: inheritedMargins)
+    }
+
     override func equals(to other: AnyRenderableBoxBase) -> Bool {
         guard let other = other as? AnyRenderableBox<Base>
             else { return false }
@@ -126,6 +116,8 @@ private class AnyRenderableBoxBase {
 
     func render(in view: UIView) { fatalError() }
     func generate() -> UIView { fatalError() }
+    func height(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat? { fatalError() }
+    func estimatedHeight(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat? { fatalError() }
     func equals(to other: AnyRenderableBoxBase) -> Bool { fatalError() }
     func delete() {}
 }

--- a/Bento/Renderable/Renderable.swift
+++ b/Bento/Renderable/Renderable.swift
@@ -1,5 +1,24 @@
 import UIKit
 
+public struct HorizontalEdgeInsets: Equatable {
+    public let leading: CGFloat
+    public let trailing: CGFloat
+
+    public init(leading: CGFloat, trailing: CGFloat) {
+        self.leading = leading
+        self.trailing = trailing
+    }
+
+    public init(_ insets: UIEdgeInsets) {
+        self.leading = insets.left
+        self.trailing = insets.right
+    }
+
+    public static var zero: HorizontalEdgeInsets {
+        return HorizontalEdgeInsets(leading: 0, trailing: 0)
+    }
+}
+
 public protocol Renderable: Equatable {
     associatedtype View
 
@@ -7,6 +26,9 @@ public protocol Renderable: Equatable {
 
     func generate() -> View
     func render(in view: View)
+
+    func height(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat?
+    func estimatedHeight(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat?
 }
 
 public extension Renderable where Self: AnyObject {
@@ -18,6 +40,56 @@ public extension Renderable where Self: AnyObject {
 public extension Renderable {
     var reuseIdentifier: String {
         return String(reflecting: View.self)
+    }
+
+    public func height(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat? {
+        return nil
+    }
+
+    public func estimatedHeight(forWidth width: CGFloat, inheritedMargins: HorizontalEdgeInsets) -> CGFloat? {
+        return nil
+    }
+}
+
+extension Renderable where View: UIView {
+    public func sizeBoundTo(width: CGFloat, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        if let height = height(forWidth: width, inheritedMargins: inheritedMargins) {
+            return CGSize(width: width, height: height)
+        }
+
+        return rendered(inheritedMargins: inheritedMargins)
+            .systemLayoutSizeFitting(CGSize(width: width, height: UILayoutFittingCompressedSize.height),
+                                     withHorizontalFittingPriority: .required,
+                                     verticalFittingPriority: .defaultLow)
+    }
+
+    public func sizeBoundTo(height: CGFloat, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        return rendered(inheritedMargins: inheritedMargins)
+            .systemLayoutSizeFitting(CGSize(width: UILayoutFittingCompressedSize.width, height: height),
+                                     withHorizontalFittingPriority: .defaultLow,
+                                     verticalFittingPriority: .required)
+    }
+
+    public func sizeBoundTo(size: CGSize, inheritedMargins: HorizontalEdgeInsets = .zero) -> CGSize {
+        if let height = height(forWidth: size.width, inheritedMargins: inheritedMargins),
+           height <= size.height {
+            return CGSize(width: size.width, height: height)
+        }
+
+        return rendered(inheritedMargins: inheritedMargins)
+            .systemLayoutSizeFitting(size)
+    }
+
+    private func rendered(inheritedMargins: HorizontalEdgeInsets) -> UIView {
+        let view = generate()
+        render(in: view)
+        let margins = view.layoutMargins
+        view.layoutMargins = UIEdgeInsets(top: margins.top,
+                                          left: max(margins.left, inheritedMargins.leading),
+                                          bottom: margins.bottom,
+                                          right: max(margins.right, inheritedMargins.trailing))
+
+        return view
     }
 }
 

--- a/Bento/Views/TableViewContainerCell.swift
+++ b/Bento/Views/TableViewContainerCell.swift
@@ -7,12 +7,14 @@ final class TableViewContainerCell: UITableViewCell {
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .none
-        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        preservesSuperviewLayoutMargins = false
+        contentView.preservesSuperviewLayoutMargins = false
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        selectionStyle = .none
+        fatalError()
     }
 
     func install(view: UIView) {

--- a/Bento/Views/TableViewHeaderFooterView.swift
+++ b/Bento/Views/TableViewHeaderFooterView.swift
@@ -5,7 +5,9 @@ final class TableViewHeaderFooterView: UITableViewHeaderFooterView {
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        preservesSuperviewLayoutMargins = false
+        contentView.preservesSuperviewLayoutMargins = false
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Allow components to supply estimated heights and actual heights, overriding the defaults specified by the `UITableView`.

1. Introduce two new optional requirements: `height(forWidth:)` and `estimatedHeight(forWidth:)`.

2. [Gardening] All `sizeBoundTo` methods have now been moved as an extension of `Renderable`, instead of being hosted by the `AnyRenderable` existential wrapper.

3. `sizeBoundTo(width:)` and `sizeBoundTo(size:)` would query the new optional requirements, and fallback to Auto Layout if necessary.

4. All sizing methods now accept optional inherited layout margins.