### PR TITLE
Extend the sizing API to support inherited layout margins.

### DIFF
--- a/Bento/Bento/Node.swift
+++ b/Bento/Bento/Node.swift
@@ -21,16 +21,16 @@ public struct Node<Identifier: Hashable>: Equatable {
         return lhs.id == rhs.id && lhs.component == rhs.component
     }
 
-    public func sizeBoundTo(width: CGFloat) -> CGSize {
-        return component.sizeBoundTo(width: width)
+    public func sizeBoundTo(width: CGFloat, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return component.sizeBoundTo(width: width, inheritedMargins: inheritedMargins)
     }
 
-    public func sizeBoundTo(height: CGFloat) -> CGSize {
-        return component.sizeBoundTo(height: height)
+    public func sizeBoundTo(height: CGFloat, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return component.sizeBoundTo(height: height, inheritedMargins: inheritedMargins)
     }
 
-    public func sizeBoundTo(size: CGSize) -> CGSize {
-        return component.sizeBoundTo(size: size)
+    public func sizeBoundTo(size: CGSize, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return component.sizeBoundTo(size: size, inheritedMargins: inheritedMargins)
     }
 }
 

--- a/Bento/Bento/Section.swift
+++ b/Bento/Bento/Section.swift
@@ -53,28 +53,28 @@ public struct Section<SectionId: Hashable, RowId: Hashable>: Equatable {
         self.rows = rows
     }
 
-    public func headerSizeBoundTo(width: CGFloat) -> CGSize {
-        return header?.sizeBoundTo(width: width) ?? .zero
+    public func headerSizeBoundTo(width: CGFloat, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return header?.sizeBoundTo(width: width, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func headerSizeBoundTo(height: CGFloat) -> CGSize {
-        return header?.sizeBoundTo(height: height) ?? .zero
+    public func headerSizeBoundTo(height: CGFloat, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return header?.sizeBoundTo(height: height, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func headerSizeBoundTo(size: CGSize) -> CGSize {
-        return header?.sizeBoundTo(size: size) ?? .zero
+    public func headerSizeBoundTo(size: CGSize, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return header?.sizeBoundTo(size: size, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func footerSizeBoundTo(width: CGFloat) -> CGSize {
-        return footer?.sizeBoundTo(width: width) ?? .zero
+    public func footerSizeBoundTo(width: CGFloat, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return footer?.sizeBoundTo(width: width, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func footerSizeBoundTo(height: CGFloat) -> CGSize {
-        return footer?.sizeBoundTo(height: height) ?? .zero
+    public func footerSizeBoundTo(height: CGFloat, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return footer?.sizeBoundTo(height: height, inheritedMargins: inheritedMargins) ?? .zero
     }
 
-    public func footerSizeBoundTo(size: CGSize) -> CGSize {
-        return footer?.sizeBoundTo(size: size) ?? .zero
+    public func footerSizeBoundTo(size: CGSize, inheritedMargins: UIEdgeInsets = .zero) -> CGSize {
+        return footer?.sizeBoundTo(size: size, inheritedMargins: inheritedMargins) ?? .zero
     }
 
     public static func hasEqualMetadata(_ lhs: Section, _ rhs: Section) -> Bool {

--- a/Bento/Renderable/AnyRenderable.swift
+++ b/Bento/Renderable/AnyRenderable.swift
@@ -31,28 +31,34 @@ struct AnyRenderable: Renderable, Deletable {
         base.render(in: view)
     }
 
-    func sizeBoundTo(width: CGFloat) -> CGSize {
-        return rendered()
+    func sizeBoundTo(width: CGFloat, inheritedMargins: UIEdgeInsets) -> CGSize {
+        return rendered(inheritedMargins: inheritedMargins)
             .systemLayoutSizeFitting(CGSize(width: width, height: UILayoutFittingCompressedSize.height),
                                                       withHorizontalFittingPriority: .required,
                                                       verticalFittingPriority: .defaultLow)
     }
 
-    func sizeBoundTo(height: CGFloat) -> CGSize {
-        return rendered()
+    func sizeBoundTo(height: CGFloat, inheritedMargins: UIEdgeInsets) -> CGSize {
+        return rendered(inheritedMargins: inheritedMargins)
             .systemLayoutSizeFitting(CGSize(width: UILayoutFittingCompressedSize.width, height: height),
                                      withHorizontalFittingPriority: .defaultLow,
                                      verticalFittingPriority: .required)
     }
 
-    func sizeBoundTo(size: CGSize) -> CGSize {
-        return rendered()
+    func sizeBoundTo(size: CGSize, inheritedMargins: UIEdgeInsets) -> CGSize {
+        return rendered(inheritedMargins: inheritedMargins)
             .systemLayoutSizeFitting(size)
     }
 
-    private func rendered() -> UIView {
+    private func rendered(inheritedMargins: UIEdgeInsets) -> UIView {
         let view = generate()
         render(in: view)
+
+        let margins = view.layoutMargins
+        view.layoutMargins = UIEdgeInsets(top: max(margins.top, inheritedMargins.top),
+                                          left: max(margins.left, inheritedMargins.left),
+                                          bottom: max(margins.bottom, inheritedMargins.bottom),
+                                          right: max(margins.right, inheritedMargins.right))
 
         return view
     }


### PR DESCRIPTION
Cherry picked from #39.

This is important for computed sizes to be correct if the layout would be affected by layout margins inherited from superviews.