### PR TITLE
Fixes swipe to delete which was broken #31

### DIFF
--- a/Bento/Adapters/TableViewAdapter.swift
+++ b/Bento/Adapters/TableViewAdapter.swift
@@ -81,7 +81,8 @@ open class TableViewAdapterBase<SectionId: Hashable, RowId: Hashable>
         return sections[section].footer == nil ? CGFloat.leastNonzeroMagnitude : UITableViewAutomaticDimension
     }
 
-    func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    @objc(tableView:editActionsForRowAtIndexPath:)
+    open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         let row = sections[indexPath.section].rows[indexPath.row]
         guard row.component.canBeDeleted else {
             return nil
@@ -95,7 +96,8 @@ open class TableViewAdapterBase<SectionId: Hashable, RowId: Hashable>
     }
 
     @available(iOS 11.0, *)
-    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    @objc(tableView:trailingSwipeActionsConfigurationForRowAtIndexPath:)
+    open func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let row = sections[indexPath.section].rows[indexPath.row]
         guard row.component.canBeDeleted else {
             return UISwipeActionsConfiguration(actions: [])


### PR DESCRIPTION
The changes made in #31 broke swipe to delete 😕 

This fixes the problem (incorrect @objc declarations for `UITableViewDelegate` methods).