### PR TITLE
Set clear color to the content view

### DIFF
--- a/Bento/Views/CollectionViewContainerCell.swift
+++ b/Bento/Views/CollectionViewContainerCell.swift
@@ -10,6 +10,7 @@ final class CollectionViewContainerCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .clear
+        contentView.backgroundColor = .clear
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Bento/Views/TableViewContainerCell.swift
+++ b/Bento/Views/TableViewContainerCell.swift
@@ -11,6 +11,7 @@ final class TableViewContainerCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .none
         backgroundColor = .clear
+        contentView.backgroundColor = .clear
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Bento/Views/TableViewHeaderFooterView.swift
+++ b/Bento/Views/TableViewHeaderFooterView.swift
@@ -9,7 +9,7 @@ final class TableViewHeaderFooterView: UITableViewHeaderFooterView {
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-        backgroundColor = .clear
+        contentView.backgroundColor = .clear
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
# Problem 

Default background color for grouped tableview is gray, which causing us issues with default renderers for loading state if table view is grouped

![simulator screen shot - iphone x - 2018-08-21 at 14 55 14](https://user-images.githubusercontent.com/4622322/44408165-bb6caf00-a557-11e8-9527-18b4f406a8ec.png)


# Why

- usage of background color is deprecated on `UITableViewHeaderFooterView`
- explicitly set `clear` color to the `contentView` of `UITableViewCell` and `UICollectionViewCell`