### PR TITLE
Grouped table view header/footer color

### DIFF
--- a/Bento/Views/TableViewHeaderFooterView.swift
+++ b/Bento/Views/TableViewHeaderFooterView.swift
@@ -9,6 +9,9 @@ final class TableViewHeaderFooterView: UITableViewHeaderFooterView {
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
+        let view = UIView()
+        view.backgroundColor = .clear
+        backgroundView = view
         contentView.backgroundColor = .clear
     }
 


### PR DESCRIPTION
As per UIKit logs:

`Setting the background color on UITableViewHeaderFooterView has been deprecated. Please set a custom UIView with your desired background color to the backgroundView property instead.`

We need to set custom view to the background view of `UITableViewHeaderFooterView` to achieve custom color.