### PR TITLE
UITableView rebinding should use the destination indices to retrieve the component.

### DIFF
--- a/Bento/Diff/TableViewSectionDiff.swift
+++ b/Bento/Diff/TableViewSectionDiff.swift
@@ -55,7 +55,7 @@ struct TableViewSectionDiff<SectionId: Hashable, RowId: Hashable> {
 
             for (source, destination) in sectionMutation.changeset.mutationIndexPairs {
                 if let cell = tableView.cellForRow(at: [sectionMutation.source, source]) as? BentoReusableView {
-                    let node = newSections[sectionMutation.source].items[source]
+                    let node = newSections[sectionMutation.destination].items[destination]
                     cell.bind(node.component)
                 }
             }


### PR DESCRIPTION
The UITableView diff applier uses the source indices to retrieve the component from the new component tree, which is incorrect as the source indices are valid only against the old component tree.