### PR TITLE
Fix glitch during delete animation for UITableView

### DIFF
--- a/Bento/Adapters/TableViewAdapter.swift
+++ b/Bento/Adapters/TableViewAdapter.swift
@@ -110,10 +110,15 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
             return
         }
 
-        component.delete()
         sections[indexPath.section].items.remove(at: indexPath.row)
+
+        CATransaction.begin()
+        CATransaction.setCompletionBlock {
+            component.delete()
+        }
         tableView?.deleteRows(at: [indexPath], with: .left)
         actionPerformed?(true)
+        CATransaction.commit()
     }
 
     private func node(at indexPath: IndexPath) -> Node<ItemID> {


### PR DESCRIPTION
This PR fixes #49

### How does it look

Before | After
--- | ---
![delete_before](https://user-images.githubusercontent.com/4622322/45501847-4b2e0380-b77a-11e8-95ff-1f2d8d106196.gif) | ![delete](https://user-images.githubusercontent.com/4622322/45502432-dfe53100-b77b-11e8-923e-eead698257cc.gif)
