### PR TITLE
Treat sections move as `insertion` + `deletion`

### DIFF
--- a/Bento/Diff/TableViewSectionDiff.swift
+++ b/Bento/Diff/TableViewSectionDiff.swift
@@ -40,8 +40,8 @@ struct TableViewSectionDiff<SectionId: Hashable, RowId: Hashable> {
         }
         tableView.insertSections(diff.sections.inserts, with: animation.sectionInsertion)
         tableView.deleteSections(diff.sections.removals, with: animation.sectionDeletion)
+        tableView.moveSections(diff.sections.moves, animation: animation)
         apply(sectionMutations: diff.mutatedSections, to: tableView, with: animation)
-        tableView.moveSections(diff.sections.moves)
         tableView.endUpdates()
     }
 
@@ -94,10 +94,9 @@ extension UITableView {
         let destination: IndexPath
     }
 
-    func moveSections(_ moves: [Changeset.Move]) {
-        for move in moves {
-            moveSection(move.source, toSection: move.destination)
-        }
+    func moveSections(_ moves: [Changeset.Move], animation: TableViewAnimation) {
+        deleteSections(IndexSet(moves.map { $0.source }), with: animation.sectionDeletion)
+        insertSections(IndexSet(moves.map { $0.destination }), with: animation.sectionInsertion)
     }
 
     func perform(moves: [Move]) {


### PR DESCRIPTION
Fix for #51

### Description

It seems that `UITableView` does not like when you move section and insert an item in it at the same time:

### Example
If we have sections transitions:
`[1, 2] - [3, 4] -> [1, 2] - [5] - [6, 3, 4]`

As you can see we insert new sections `[5]` and move `[3, 4]` and at the same time insert an item `6` 

### Proposed solution

The solution is to treat moves of the sections as removal and insertion