### PR TITLE
Use destination  section for destination indexPath

### DIFF
--- a/Bento/Diff/TableViewSectionDiff.swift
+++ b/Bento/Diff/TableViewSectionDiff.swift
@@ -75,7 +75,7 @@ extension SectionedChangeset.MutatedSection {
     var movedIndexPaths: [UITableView.Move] {
         return changeset.moves.map {
             let source = IndexPath(row: $0.source, section: self.source)
-            let destination = IndexPath(row: $0.destination, section: self.source)
+            let destination = IndexPath(row: $0.destination, section: self.destination)
 
             return UITableView.Move(source: source, destination: destination)
         }


### PR DESCRIPTION
There is a bug in code, probably because of copy-pasting 🙈, which will lead to crashes in case we have a crosse section move

