### PR TITLE
Add support for `UIMenuController` actions when user long press item in [UI]TableView/CollectionView 

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		5829D26E200FB092001E020D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5829D26C200FB092001E020D /* Main.storyboard */; };
 		5829D270200FB092001E020D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5829D26F200FB092001E020D /* Assets.xcassets */; };
 		5829D273200FB092001E020D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5829D271200FB092001E020D /* LaunchScreen.storyboard */; };
+		582D9951217E196E00C67B0D /* MenuItemsResponding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582D9950217E196E00C67B0D /* MenuItemsResponding.swift */; };
 		582D9987217F87B100C67B0D /* ComponentLifecycleAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582D9986217F87B100C67B0D /* ComponentLifecycleAware.swift */; };
 		58467B03202B33F200577C77 /* TableViewSectionDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58467B02202B33F200577C77 /* TableViewSectionDiff.swift */; };
 		584A6F9E20C7E36D006395E8 /* IntroComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584A6F9D20C7E36D006395E8 /* IntroComponent.swift */; };
@@ -129,6 +130,7 @@
 		5829D26F200FB092001E020D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5829D272200FB092001E020D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5829D274200FB092001E020D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		582D9950217E196E00C67B0D /* MenuItemsResponding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuItemsResponding.swift; sourceTree = "<group>"; };
 		582D9986217F87B100C67B0D /* ComponentLifecycleAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentLifecycleAware.swift; sourceTree = "<group>"; };
 		58467B02202B33F200577C77 /* TableViewSectionDiff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewSectionDiff.swift; sourceTree = "<group>"; };
 		584A6F9D20C7E36D006395E8 /* IntroComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroComponent.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 				58E98E62201889B900F78BAE /* AnyRenderable.swift */,
 				587A341E2100A09B00B25CCA /* Deletable.swift */,
 				65E3EC9F2113114100869DF3 /* Focusable.swift */,
+				582D9950217E196E00C67B0D /* MenuItemsResponding.swift */,
 				65E3ECAB2113591500869DF3 /* FocusableView.swift */,
 				65E3ECA1211317EA00869DF3 /* FocusCoordinator.swift */,
 				65E3ECA521133C9400869DF3 /* UIKit+CollectionViewFocus.swift */,
@@ -628,6 +631,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				582D9951217E196E00C67B0D /* MenuItemsResponding.swift in Sources */,
 				9AF4786A21205E3100F87E21 /* Supplement.swift in Sources */,
 				65496FB8211C323F00511D8A /* TableViewContainerCell.swift in Sources */,
 				65496FB9211C323F00511D8A /* TableViewAdapter.swift in Sources */,

--- a/Bento/Adapters/CollectionViewAdapter.swift
+++ b/Bento/Adapters/CollectionViewAdapter.swift
@@ -103,6 +103,27 @@ open class CollectionViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
         view.didEndDisplayingView()
     }
 
+    @objc(collectionView:shouldShowMenuForItemAtIndexPath:)
+    open func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
+        guard let component = sections[indexPath.section].items[indexPath.row].component(as: MenuItemsResponding.self) else {
+            return false
+        }
+        UIMenuController.shared.menuItems = component.menuItems
+        return true
+    }
+
+    @objc(collectionView:canPerformAction:forItemAtIndexPath:withSender:)
+    open func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
+        guard let component = sections[indexPath.section].items[indexPath.row].component(as: MenuItemsResponding.self) else {
+            return false
+        }
+
+        return component.responds(to: action)
+    }
+
+    @objc(collectionView:performAction:forItemAtIndexPath:withSender:)
+    open func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {}
+
     private func node(at indexPath: IndexPath) -> Node<ItemID> {
         return sections[indexPath.section].items[indexPath.row]
     }

--- a/Bento/Adapters/TableViewAdapter.swift
+++ b/Bento/Adapters/TableViewAdapter.swift
@@ -138,6 +138,27 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
         view.didEndDisplayingView()
     }
 
+    @objc(tableView:shouldShowMenuForRowAtIndexPath:)
+    open func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {
+        guard let component = sections[indexPath.section].items[indexPath.row].component(as: MenuItemsResponding.self) else {
+            return false
+        }
+        UIMenuController.shared.menuItems = component.menuItems
+        return true
+    }
+
+    @objc(tableView:canPerformAction:forRowAtIndexPath:withSender:)
+    open func tableView(_ tableView: UITableView, canPerformAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
+        guard let component = sections[indexPath.section].items[indexPath.row].component(as: MenuItemsResponding.self) else {
+            return false
+        }
+
+        return component.responds(to: action)
+    }
+
+    @objc(tableView:performAction:forRowAtIndexPath:withSender:)
+    open func tableView(_ tableView: UITableView, performAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) {}
+
     private func deleteRow(at indexPath: IndexPath, actionPerformed: ((Bool) -> Void)?) {
         let item = sections[indexPath.section].items[indexPath.row]
         guard let component = item.component(as: Deletable.self) else {

--- a/Bento/Renderable/MenuItemsResponding.swift
+++ b/Bento/Renderable/MenuItemsResponding.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+public protocol MenuItemsResponding: NSObjectProtocol {
+    var menuItems: [UIMenuItem] { get }
+}

--- a/Bento/Views/CollectionViewContainerCell.swift
+++ b/Bento/Views/CollectionViewContainerCell.swift
@@ -18,6 +18,22 @@ final class CollectionViewContainerCell: UICollectionViewCell {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func responds(to aSelector: Selector!) -> Bool {
+        guard let component = component?.cast(to: MenuItemsResponding.self) else {
+            return super.responds(to: aSelector)
+        }
+
+        return component.responds(to: aSelector) || super.responds(to: aSelector)
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        guard let component = component?.cast(to: MenuItemsResponding.self) else {
+            return super.forwardingTarget(for: aSelector)
+        }
+
+        return component
+    }
 }
 
 extension CollectionViewContainerCell: BentoReusableView {}

--- a/Bento/Views/CollectionViewContainerReusableView.swift
+++ b/Bento/Views/CollectionViewContainerReusableView.swift
@@ -21,6 +21,22 @@ final class CollectionViewContainerReusableView: UICollectionReusableView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func responds(to aSelector: Selector!) -> Bool {
+        guard let component = component?.cast(to: MenuItemsResponding.self) else {
+            return super.responds(to: aSelector)
+        }
+
+        return component.responds(to: aSelector) || super.responds(to: aSelector)
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        guard let component = component?.cast(to: MenuItemsResponding.self) else {
+            return super.forwardingTarget(for: aSelector)
+        }
+
+        return component
+    }
 }
 
 extension CollectionViewContainerReusableView: BentoReusableView {}

--- a/Bento/Views/TableViewContainerCell.swift
+++ b/Bento/Views/TableViewContainerCell.swift
@@ -20,6 +20,22 @@ final class TableViewContainerCell: UITableViewCell {
         super.init(coder: aDecoder)
         selectionStyle = .none
     }
+
+    override func responds(to aSelector: Selector!) -> Bool {
+        guard let component = component?.cast(to: MenuItemsResponding.self) else {
+            return super.responds(to: aSelector)
+        }
+
+        return component.responds(to: aSelector) || super.responds(to: aSelector)
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        guard let component = component?.cast(to: MenuItemsResponding.self) else {
+            return super.forwardingTarget(for: aSelector)
+        }
+
+        return component
+    }
 }
 
 extension TableViewContainerCell: BentoReusableView {}

--- a/Bento/Views/TableViewHeaderFooterView.swift
+++ b/Bento/Views/TableViewHeaderFooterView.swift
@@ -20,6 +20,23 @@ final class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func responds(to aSelector: Selector!) -> Bool {
+        guard let component = component?.cast(to: MenuItemsResponding.self) else {
+            return super.responds(to: aSelector)
+        }
+
+        return component.responds(to: aSelector) || super.responds(to: aSelector)
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        guard let component = component?.cast(to: MenuItemsResponding.self) else {
+            return super.forwardingTarget(for: aSelector)
+        }
+
+        return component
+    }
+
 }
 
 extension TableViewHeaderFooterView: BentoReusableView {}


### PR DESCRIPTION
## Description 

We need to have ability to add custom actions to `UIMenuController`

#### How UIKit manages `UIMenuController` with custom actions:

1. Users need to set array of actions they want to add

```swift
UIMenuController.shared.menuItems = [UIMenuItem(title: "Report", action: #selector(someMethod))]
```

2. Then [UI]CollectionView/TableView delegate should implement all 3 methods related to menu items

```swift
func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool

func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool 

public func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?)
```

3. Then UIKit will ask `UICollectionViewCell` whether it responds to that selector (if not UIKit will ignore and won't show custom action in the pop up)


## Proposed solution

1. Introduce `MenuItemsResponding`
```swift
public protocol MenuItemsResponding: NSObjectProtocol {
    var menuItems: [UIMenuItem] { get }
}
```

As you may notice we need to have `NSObjectProtocol` (we'll need it later to use for message forwarding)

2. Then in `CollectionViewContainerCell` we simply forward all messages that associated with `MenuItemsResponding` to the component object

```swift
final class CollectionViewContainerCell: UICollectionViewCell {
    override func responds(to aSelector: Selector!) -> Bool {
        guard let component = component?.cast(to: MenuItemsResponding.self) else {
            return super.responds(to: aSelector)
        }

        return component.responds(to: aSelector) || super.responds(to: aSelector)
    }

    override func forwardingTarget(for aSelector: Selector!) -> Any? {
        guard let component = component?.cast(to: MenuItemsResponding.self) else {
            return super.forwardingTarget(for: aSelector)
        }

        return component
    }
}
```

3. What we need from the client side:

- Define a component which conforms to `MenuItemsResponding ` and add a `@objc` method to it

```swift
extension Component {
    final class IncomingMessage: NSObject, AutoRenderable, MenuItemsResponding {
       var menuItems: [UIMenuItem] {
              return [
                     UIMenuItem(title: "Report", action: #selector(didReportItem))
              ]
        }

        @objc
        func didReportItem() {
            print(#function)
        }
    }
}
```

## How does it look:

![custom_menu_item](https://user-images.githubusercontent.com/4622322/47860486-8e0a7000-dde8-11e8-8e9e-27e629b8b185.gif)