### PR TITLE
Support for `NavigationTitleItem` in `Screen`. Resolves #61

### DIFF
--- a/BentoKit/BentoKit/Screen/BoxViewController.swift
+++ b/BentoKit/BentoKit/Screen/BoxViewController.swift
@@ -295,7 +295,13 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
         screen: Screen<Renderer.SectionID, Renderer.ItemID>,
         usesSystemSeparator: Bool
     ) {
-        navigationItem.title = screen.title
+        switch screen.titleItem {
+        case let .text(text):
+            navigationItem.title = text
+        case let .view(view):
+            navigationItem.titleView = view
+        }
+
         renderBarItems(reference: \.previousLeftBarItems,
                        new: screen.leftBarItems,
                        setItems: navigationItem.setLeftBarButtonItems(_:animated:),

--- a/BentoKit/BentoKit/Screen/Screen.swift
+++ b/BentoKit/BentoKit/Screen/Screen.swift
@@ -37,7 +37,7 @@ public struct Screen<SectionId: Hashable, RowId: Hashable> {
     }
 
     public init(
-        titleItem: NavigationTitleItem = .text(""),
+        titleItem: NavigationTitleItem,
         leftBarItems: [BarButtonItem] = [],
         rightBarItems: [BarButtonItem] = [],
         formStyle: BentoTableView.Layout = .topYAligned,

--- a/BentoKit/BentoKit/Screen/Screen.swift
+++ b/BentoKit/BentoKit/Screen/Screen.swift
@@ -3,7 +3,7 @@ import Bento
 public struct Screen<SectionId: Hashable, RowId: Hashable> {
     public let leftBarItems: [BarButtonItem]
     public let rightBarItems: [BarButtonItem]
-    public let title: String
+    public let titleItem: NavigationTitleItem
     public let formStyle: BentoTableView.Layout
     public let focusMode: FocusMode
     /// If not nil will override renderer configuration property
@@ -23,9 +23,33 @@ public struct Screen<SectionId: Hashable, RowId: Hashable> {
         pinnedToTopBox: Box<SectionId, RowId> = .empty,
         pinnedToBottomBox: Box<SectionId, RowId> = .empty
     ) {
+        self.init(
+            titleItem: .text(title),
+            leftBarItems: leftBarItems,
+            rightBarItems: rightBarItems,
+            formStyle: formStyle,
+            focusMode: focusMode,
+            shouldUseSystemSeparators: shouldUseSystemSeparators,
+            box: box,
+            pinnedToTopBox: pinnedToTopBox,
+            pinnedToBottomBox: pinnedToBottomBox
+        )
+    }
+
+    public init(
+        titleItem: NavigationTitleItem = .text(""),
+        leftBarItems: [BarButtonItem] = [],
+        rightBarItems: [BarButtonItem] = [],
+        formStyle: BentoTableView.Layout = .topYAligned,
+        focusMode: FocusMode = .never,
+        shouldUseSystemSeparators: Bool? = nil,
+        box: Box<SectionId, RowId>,
+        pinnedToTopBox: Box<SectionId, RowId> = .empty,
+        pinnedToBottomBox: Box<SectionId, RowId> = .empty
+    ) {
         self.leftBarItems = leftBarItems
         self.rightBarItems = rightBarItems
-        self.title = title
+        self.titleItem = titleItem
         self.formStyle = formStyle
         self.focusMode = focusMode
         self.shouldUseSystemSeparators = shouldUseSystemSeparators

--- a/BentoKit/BentoKit/Screen/Screen.swift
+++ b/BentoKit/BentoKit/Screen/Screen.swift
@@ -13,7 +13,7 @@ public struct Screen<SectionId: Hashable, RowId: Hashable> {
     public let pinnedToBottomBox: Box<SectionId, RowId>
 
     public init(
-        title: String = "",
+        title: String,
         leftBarItems: [BarButtonItem] = [],
         rightBarItems: [BarButtonItem] = [],
         formStyle: BentoTableView.Layout = .topYAligned,

--- a/BentoKit/BentoKitTests/SnapshotTests/Screen/BoxViewControllerSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Screen/BoxViewControllerSnapshotTests.swift
@@ -11,9 +11,26 @@ final class BoxViewControllerSnapshotTests: SnapshotTestCase {
         self.recordMode = false
     }
 
-    func testWithYCenterAligned() {
+    func testWithYCenterAligned_StringTitle() {
         Device.all.forEach {
-            let vm = ViewModel()
+            let vm = ViewModel(state: .text("String Title"))
+            let vc = BoxViewController(viewModel: vm,
+                                       renderer: Renderer.self,
+                                       rendererConfig: (),
+                                       appearance: Property(value: TestAppearance()))
+            let nc = UINavigationController(rootViewController: vc)
+            verify(viewController: nc, for: $0)
+        }
+    }
+
+    func testWithYCenterAligned_ViewTitle() {
+        let view = UILabel()
+        view.text = "View Title"
+        view.layer.borderColor = UIColor.red.cgColor
+        view.layer.borderWidth = 1
+
+        Device.all.forEach {
+            let vm = ViewModel(state: .view(view))
             let vc = BoxViewController(viewModel: vm,
                                        renderer: Renderer.self,
                                        rendererConfig: (),
@@ -24,10 +41,14 @@ final class BoxViewControllerSnapshotTests: SnapshotTestCase {
     }
 
     class ViewModel: BoxViewModel {
-        typealias State = String
+        typealias State = NavigationTitleItem
         typealias Action = Never
 
-        let state = Property(value: "Unable to connect")
+        let state: Property<State>
+
+        init(state: State) {
+            self.state = Property(value: state)
+        }
 
         func send(action: Never) {}
     }
@@ -37,7 +58,7 @@ final class BoxViewControllerSnapshotTests: SnapshotTestCase {
     }
 
     struct Renderer: BoxRenderer {
-        typealias State = String
+        typealias State = NavigationTitleItem
         typealias Action = Never
         typealias SectionId = Int
         typealias RowId = Int
@@ -56,7 +77,7 @@ final class BoxViewControllerSnapshotTests: SnapshotTestCase {
             self.observer = observer
         }
 
-        func render(state: String) -> Screen<SectionId, RowId> {
+        func render(state: NavigationTitleItem) -> Screen<SectionId, RowId> {
             let rightButtons = [
                 BarButtonItem(appearance: .text("R"))
             ]
@@ -65,7 +86,7 @@ final class BoxViewControllerSnapshotTests: SnapshotTestCase {
                 BarButtonItem(appearance: .text("L"))
             ]
             return Screen(
-                title: "Title",
+                titleItem: state,
                 leftBarItems: leftButtons,
                 rightBarItems: rightButtons,
                 formStyle: .centerYAligned,

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_StringTitle_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_StringTitle_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b7e4b926990a9a5fccc9d9bcd987f2ee340e70d964483940b8b29e0da9b7f4e
+size 25302

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_StringTitle_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_StringTitle_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19bb1ad6ca0dac20c466d2de9f848f6571b164fd66e10c517594632fadb2096a
+size 29208

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_StringTitle_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_StringTitle_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5b566ef8a8662fa7b226c03debe8826fbbfc5d3c67f97926ba67b1c7463df2e
+size 29792

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_ViewTitle_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_ViewTitle_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e72c8e12986311278444848740214a1b2ed6d9f1b03da152621b4d25ef352d3b
+size 25267

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_ViewTitle_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_ViewTitle_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59bcbf74b814b6aabb49fcdc4f918a2062eabc49e46ae95449797a55bffd5910
+size 29195

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_ViewTitle_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_ViewTitle_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bc0780f9677948d2ae3d6239258fc6cdbe2975e01e11d1dbc185d9a374492fc
+size 29757

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_iPhone6@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ec52b86d3f6bd24869b22c4f3b36127d32ae0ce162a991426b7cd725dd1c277
-size 23479

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_iPhone6Plus@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c46995861a24b6bfa5591cd19af447826cf786a588ffe8e2cca51ffac7b3311b
-size 27305

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/testWithYCenterAligned_iPhoneX@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4786ff960fea7ada69d893e3e3ac12f534776326985c8455d9eab7996d882d6b
-size 27929


### PR DESCRIPTION
Adds support for using `NavigationTitleItem` in `Screen`, so that you can use images (or any other `UIView` for the navigation title.

Snapshot tests updated.

Resolves #61 