### PR TITLE
Fix the podspec for BentoKit.

### DIFF
--- a/BentoKit.podspec
+++ b/BentoKit.podspec
@@ -15,11 +15,14 @@ Pod::Spec.new do |s|
 
 # Switch back to use the version tag when we release 0.4.
   s.source        = { :git => "https://github.com/Babylonpartners/Bento.git", :branch => "develop" } #, :tag => "#{s.version}" }
-  s.source_files  = 'BentoKit/*.swift', 'BentoKit/**/*.swift'
+  s.source_files  = 'BentoKit/BentoKit/**/*.swift'
+  s.exclude_files = 'BentoKit/BentoKit/Components.playground/**/*'
 
   s.swift_version = "4.2"
 # Switch back to use the master spec when we release 0.4.
-  s.dependency "Bento" 
+  s.dependency "Bento"
   s.dependency "StyleSheets"
   s.dependency "FlexibleDiff", "= 0.0.5"
+  s.dependency "ReactiveSwift", "~> 4.0.0"
+  s.dependency "ReactiveCocoa", "~> 8.0.2"
 end


### PR DESCRIPTION
The BentoKit podspec included too many source files, in particular, the playground files which caused a number of duplicate files.

Also, the RAS and RAC dependencies weren't there.