### PR TITLE
Add ComponentLifecycle aware conformance for TitledDescription

### DIFF
--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -17,10 +17,11 @@ public extension Component {
     /// While `TitledDescription` supports asynchronous loading for its image
     /// view, you are obligated to ensure a consistent fixed size across all
     /// changes.
-    public final class TitledDescription: AutoRenderable, Deletable, HeightCustomizing, Focusable {
-
+    public final class TitledDescription: AutoRenderable, Deletable, HeightCustomizing, Focusable, ComponentLifecycleAware {
         public typealias Accessory = AccessoryView.Accessory
 
+        private let _willDisplayItem: (() -> Void)?
+        private let _didEndDisplayingItem: (() -> Void)?
         public let focusEligibility: FocusEligibility
         public let configurator: (View) -> Void
         public let deleteActionText: String
@@ -58,6 +59,8 @@ public extension Component {
             didTap: Optional<() -> Void> = nil,
             didTapAccessory: Optional<() -> Void> = nil,
             deleteAction: DeleteAction = .none,
+            willDisplayItem: (() -> Void)? = nil,
+            didEndDisplayingItem: (() -> Void)? = nil,
             styleSheet: StyleSheet = .init()
         ) {
             let titleText: TextValue
@@ -92,6 +95,8 @@ public extension Component {
                 didTap: didTap,
                 didTapAccessory: didTapAccessory,
                 deleteAction: deleteAction,
+                willDisplayItem: willDisplayItem,
+                didEndDisplayingItem: didEndDisplayingItem,
                 styleSheet: styleSheet
             )
         }
@@ -107,6 +112,8 @@ public extension Component {
             didTap: (() -> Void)? = nil,
             didTapAccessory: (() -> Void)? = nil,
             deleteAction: DeleteAction = .none,
+            willDisplayItem: (() -> Void)? = nil,
+            didEndDisplayingItem: (() -> Void)? = nil,
             styleSheet: StyleSheet = .init()
         ) {
             self.configurator = { view in
@@ -153,10 +160,20 @@ public extension Component {
             self.styleSheet = styleSheet
             self.deleteActionText = deleteAction.title ?? ""
             self.didDelete = deleteAction.callback
+            self._willDisplayItem = willDisplayItem
+            self._didEndDisplayingItem = didEndDisplayingItem
         }
 
         private let heightComputer: (CGFloat, UIEdgeInsets) -> CGFloat
         private let didDelete: (() -> Void)?
+        
+        public func willDisplayItem() {
+            _willDisplayItem?()
+        }
+        
+        public func didEndDisplayingItem() {
+            _didEndDisplayingItem?()
+        }
     }
 }
 


### PR DESCRIPTION
Because of the long transition `TitledDescription` in our main repo ended up having `ComponentLyfecycleAware` behaviour while the one here does not ¯\_(ツ)_/¯