### PR TITLE
Added search bar component

### DIFF
--- a/BentoKit/BentoKit.xcodeproj/project.pbxproj
+++ b/BentoKit/BentoKit.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		A6EC2DBD218B298B002B128F /* HostWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6EC2DBC218B298A002B128F /* HostWindow.swift */; };
 		B5234D63216EB0060061AD8B /* ImageOrLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234D62216EB0060061AD8B /* ImageOrLabel.swift */; };
 		B5BD11C6219301D500DC6A51 /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BD11C5219301D500DC6A51 /* Search.swift */; };
+		B5BD11C821930A2400DC6A51 /* SearchSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BD11C721930A2400DC6A51 /* SearchSnapshotTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -186,6 +187,7 @@
 		A6EC2DBC218B298A002B128F /* HostWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HostWindow.swift; sourceTree = "<group>"; };
 		B5234D62216EB0060061AD8B /* ImageOrLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageOrLabel.swift; sourceTree = "<group>"; };
 		B5BD11C5219301D500DC6A51 /* Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
+		B5BD11C721930A2400DC6A51 /* SearchSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSnapshotTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -405,6 +407,7 @@
 				58801186216271DA0084EE07 /* TitledDescriptionSnapshotTests.swift */,
 				5880118A216271DA0084EE07 /* TitledDescriptionLegacySnapshotTests.swift */,
 				58801187216271DA0084EE07 /* ToggleSnapshotTests.swift */,
+				B5BD11C721930A2400DC6A51 /* SearchSnapshotTests.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -675,6 +678,7 @@
 				58801197216271DB0084EE07 /* ActivityComponentSnapshotTests.swift in Sources */,
 				58801191216271DB0084EE07 /* TitledDescriptionSnapshotTests.swift in Sources */,
 				58801192216271DB0084EE07 /* ToggleSnapshotTests.swift in Sources */,
+				B5BD11C821930A2400DC6A51 /* SearchSnapshotTests.swift in Sources */,
 				A6EC2DB5218B28BF002B128F /* BoxViewControllerSnapshotTests.swift in Sources */,
 				58801193216271DB0084EE07 /* ButtonComponentSnapshotTests.swift in Sources */,
 			);

--- a/BentoKit/BentoKit.xcodeproj/project.pbxproj
+++ b/BentoKit/BentoKit.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		A6EC2DBB218B2912002B128F /* Bool+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6EC2DB8218B2912002B128F /* Bool+Assertions.swift */; };
 		A6EC2DBD218B298B002B128F /* HostWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6EC2DBC218B298A002B128F /* HostWindow.swift */; };
 		B5234D63216EB0060061AD8B /* ImageOrLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234D62216EB0060061AD8B /* ImageOrLabel.swift */; };
+		B5BD11C6219301D500DC6A51 /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BD11C5219301D500DC6A51 /* Search.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -184,6 +185,7 @@
 		A6EC2DB8218B2912002B128F /* Bool+Assertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bool+Assertions.swift"; sourceTree = "<group>"; };
 		A6EC2DBC218B298A002B128F /* HostWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HostWindow.swift; sourceTree = "<group>"; };
 		B5234D62216EB0060061AD8B /* ImageOrLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageOrLabel.swift; sourceTree = "<group>"; };
+		B5BD11C5219301D500DC6A51 /* Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -273,6 +275,7 @@
 				580B6127215D2F6800A69E87 /* TextInput.swift */,
 				580B612B215D2F6800A69E87 /* TitledDescription.swift */,
 				580B6122215D2F6700A69E87 /* Toggle.swift */,
+				B5BD11C5219301D500DC6A51 /* Search.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -624,6 +627,7 @@
 				580B612F215D2F6800A69E87 /* Toggle.swift in Sources */,
 				580B612E215D2F6800A69E87 /* Component.swift in Sources */,
 				580B614A215D353B00A69E87 /* InputNodes.swift in Sources */,
+				B5BD11C6219301D500DC6A51 /* Search.swift in Sources */,
 				580B6134215D2F6800A69E87 /* TextInput.swift in Sources */,
 				A6EC2DB0218B28AA002B128F /* BoxViewModel.swift in Sources */,
 				580B611F215D2F6100A69E87 /* HeightCustomizing.swift in Sources */,

--- a/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/Contents.swift
+++ b/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/Contents.swift
@@ -7,7 +7,7 @@ import StyleSheets
 
 let bundle = Bundle(for: Component.TextInput.self)
 let styleSheet = Component.Search.StyleSheet()
-    .compose(\.searchBar.backgroundColor, UIColor.gray.withAlphaComponent(0.25))
+    .compose(\.searchBar.textInputBackgroundColor, UIColor.gray.withAlphaComponent(0.25))
     .compose(\.searchBar.showsCancelButton, true)
 let component = Component.Search(
     placeholder: "Placeholder",

--- a/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/Contents.swift
+++ b/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/Contents.swift
@@ -8,7 +8,7 @@ import StyleSheets
 let bundle = Bundle(for: Component.TextInput.self)
 let styleSheet = Component.Search.StyleSheet()
     .compose(\.searchBar.backgroundColor, UIColor.gray.withAlphaComponent(0.25))
-.compose(\.searchBar.showsCancelButton, true)
+    .compose(\.searchBar.showsCancelButton, true)
 let component = Component.Search(
     placeholder: "Placeholder",
     keyboardType: .default,

--- a/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/Contents.swift
+++ b/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/Contents.swift
@@ -12,11 +12,15 @@ let styleSheet = Component.Search.StyleSheet()
 let component = Component.Search(
     placeholder: "Placeholder",
     keyboardType: .default,
-    textDidChange: {
-        print("textDidChange", $0)
+    didBeginEditing: { _ in
+        print("didBeginEditing")
+},
+    textDidChange: { _, text in
+        print("textDidChange", text)
 },
     cancelButtonClicked: {
         print("cancelButtonClicked")
+        $0.endEditing(true)
 },
     styleSheet: styleSheet
 )

--- a/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/Contents.swift
+++ b/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/Contents.swift
@@ -1,0 +1,24 @@
+import UIKit
+import Bento
+import BentoKit
+import BentoKitPlaygroundSupport
+import PlaygroundSupport
+import StyleSheets
+
+let bundle = Bundle(for: Component.TextInput.self)
+let styleSheet = Component.Search.StyleSheet()
+    .compose(\.searchBar.backgroundColor, UIColor.gray.withAlphaComponent(0.25))
+.compose(\.searchBar.showsCancelButton, true)
+let component = Component.Search(
+    placeholder: "Placeholder",
+    keyboardType: .default,
+    textDidChange: {
+        print("textDidChange", $0)
+},
+    cancelButtonClicked: {
+        print("cancelButtonClicked")
+},
+    styleSheet: styleSheet
+)
+
+PlaygroundPage.current.liveView = renderInTableView(component: component)

--- a/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/timeline.xctimeline
+++ b/BentoKit/BentoKit/Components.playground/Pages/Search.xcplaygroundpage/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/BentoKit/BentoKit/Components.playground/contents.xcplayground
+++ b/BentoKit/BentoKit/Components.playground/contents.xcplayground
@@ -9,5 +9,6 @@
         <page name='MultilineTextInput'/>
         <page name='TextInput'/>
         <page name='TitledDescription'/>
+        <page name='Search'/>
     </pages>
 </playground>

--- a/BentoKit/BentoKit/Components/Search.swift
+++ b/BentoKit/BentoKit/Components/Search.swift
@@ -12,7 +12,7 @@ extension Component {
             didBeginEditing: Optional<(UISearchBar) -> Void> = nil,
             textDidChange: Optional<(UISearchBar, String) -> Void> = nil,
             cancelButtonClicked: Optional<(UISearchBar) -> Void> = nil,
-            styleSheet: StyleSheet
+            styleSheet: StyleSheet = StyleSheet()
             ) {
             self.configurator = { view in
                 view.searchBar.placeholder = placeholder

--- a/BentoKit/BentoKit/Components/Search.swift
+++ b/BentoKit/BentoKit/Components/Search.swift
@@ -9,13 +9,15 @@ extension Component {
         public init(
             placeholder: String? = nil,
             keyboardType: UIKeyboardType = .default,
-            textDidChange: Optional<(String) -> Void> = nil,
-            cancelButtonClicked: Optional<() -> Void> = nil,
+            didBeginEditing: Optional<(UISearchBar) -> Void> = nil,
+            textDidChange: Optional<(UISearchBar, String) -> Void> = nil,
+            cancelButtonClicked: Optional<(UISearchBar) -> Void> = nil,
             styleSheet: StyleSheet
             ) {
             self.configurator = { view in
                 view.searchBar.placeholder = placeholder
                 view.searchBar.keyboardType = keyboardType
+                view.didBeginEditing = didBeginEditing
                 view.textDidChange = textDidChange
                 view.cancelButtonClicked = cancelButtonClicked
             }
@@ -29,9 +31,9 @@ extension Component.Search {
 
         fileprivate let searchBar = UISearchBar()
 
-        var textDidChange: Optional<(String) -> Void> = nil
-        var cancelButtonClicked: Optional<() -> Void> = nil
-        var didBeginEditing: Optional<() -> Void> = nil
+        var textDidChange: Optional<(UISearchBar, String) -> Void> = nil
+        var cancelButtonClicked: Optional<(UISearchBar) -> Void> = nil
+        var didBeginEditing: Optional<(UISearchBar) -> Void> = nil
 
         public override init(frame: CGRect) {
             super.init(frame: frame)
@@ -51,7 +53,7 @@ extension Component.Search {
         }
 
         public func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
-            self.didBeginEditing?()
+            self.didBeginEditing?(searchBar)
         }
 
         public func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
@@ -59,11 +61,11 @@ extension Component.Search {
         }
 
         public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-            self.textDidChange?(searchText)
+            self.textDidChange?(searchBar, searchText)
         }
 
         public func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-            self.cancelButtonClicked?()
+            self.cancelButtonClicked?(searchBar)
         }
     }
 }

--- a/BentoKit/BentoKit/Components/Search.swift
+++ b/BentoKit/BentoKit/Components/Search.swift
@@ -29,7 +29,7 @@ extension Component {
 extension Component.Search {
     public final class View: BaseView, UISearchBarDelegate {
 
-        fileprivate let searchBar = UISearchBar()
+        let searchBar = UISearchBar()
 
         var textDidChange: Optional<(UISearchBar, String) -> Void> = nil
         var cancelButtonClicked: Optional<(UISearchBar) -> Void> = nil
@@ -39,8 +39,8 @@ extension Component.Search {
             super.init(frame: frame)
 
             searchBar.add(to: self)
-                .height(36)
                 .pinEdges(to: layoutMarginsGuide)
+
             searchBar.backgroundColor = .white
             searchBar.barTintColor = .white
             searchBar.backgroundImage = UIImage()
@@ -83,6 +83,7 @@ extension Component.Search {
             public var enablesReturnKeyAutomatically: Bool = true
 
             public func apply(to element: UISearchBar) {
+                element.height(height)
                 element.setTextInputBackgroundColor(color: backgroundColor,
                                                     height: height,
                                                     cornerRadius: cornerRadius)

--- a/BentoKit/BentoKit/Components/Search.swift
+++ b/BentoKit/BentoKit/Components/Search.swift
@@ -70,7 +70,7 @@ extension Component.Search {
 
 extension Component.Search {
     public final class StyleSheet: BaseViewStyleSheet<View> {
-        public var searchBar = SearchBarStyleSheet()
+        public let searchBar = SearchBarStyleSheet()
 
         public init() {}
 

--- a/BentoKit/BentoKit/Components/Search.swift
+++ b/BentoKit/BentoKit/Components/Search.swift
@@ -1,0 +1,123 @@
+import Bento
+import StyleSheets
+
+extension Component {
+    public final class Search: AutoRenderable {
+        public let configurator: (View) -> Void
+        public let styleSheet: StyleSheet
+
+        public init(
+            placeholder: String? = nil,
+            keyboardType: UIKeyboardType = .default,
+            textDidChange: Optional<(String) -> Void> = nil,
+            cancelButtonClicked: Optional<() -> Void> = nil,
+            styleSheet: StyleSheet
+            ) {
+            self.configurator = { view in
+                view.searchBar.placeholder = placeholder
+                view.searchBar.keyboardType = keyboardType
+                view.textDidChange = textDidChange
+                view.cancelButtonClicked = cancelButtonClicked
+            }
+            self.styleSheet = styleSheet
+        }
+    }
+}
+
+extension Component.Search {
+    public final class View: BaseView, UISearchBarDelegate {
+
+        fileprivate let searchBar = UISearchBar()
+
+        var textDidChange: Optional<(String) -> Void> = nil
+        var cancelButtonClicked: Optional<() -> Void> = nil
+        var didBeginEditing: Optional<() -> Void> = nil
+
+        public override init(frame: CGRect) {
+            super.init(frame: frame)
+
+            searchBar.add(to: self)
+                .height(36)
+                .pinEdges(to: layoutMarginsGuide)
+            searchBar.backgroundColor = .white
+            searchBar.barTintColor = .white
+            searchBar.backgroundImage = UIImage()
+            searchBar.delegate = self
+        }
+
+        @available(*, unavailable)
+        public required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        public func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+            self.didBeginEditing?()
+        }
+
+        public func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+            searchBar.endEditing(true)
+        }
+
+        public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+            self.textDidChange?(searchText)
+        }
+
+        public func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+            self.cancelButtonClicked?()
+        }
+    }
+}
+
+extension Component.Search {
+    public final class StyleSheet: BaseViewStyleSheet<View> {
+        public struct SearchBar: StyleSheetProtocol {
+            public var backgroundColor: UIColor = .white
+            public var cornerRadius: CGFloat = 10
+            public var height: CGFloat = 36
+            public var showsCancelButton: Bool = false
+            public var searchTextPositionAdjustment: UIOffset = UIOffset.init(horizontal: 8, vertical: 0)
+            public var keyboardType: UIKeyboardType = .default
+            public var returnKeyType: UIReturnKeyType = .search
+            public var enablesReturnKeyAutomatically: Bool = true
+
+            public func apply(to element: UISearchBar) {
+                element.setTextInputBackgroundColor(color: backgroundColor,
+                                                    height: height,
+                                                    cornerRadius: cornerRadius)
+                element.showsCancelButton = showsCancelButton
+                element.searchTextPositionAdjustment = searchTextPositionAdjustment
+                element.keyboardType = keyboardType
+                element.returnKeyType = returnKeyType
+                element.enablesReturnKeyAutomatically = enablesReturnKeyAutomatically
+            }
+        }
+        public var searchBar: SearchBar = SearchBar()
+
+        public init() {}
+
+        public override func apply(to element: View) {
+            super.apply(to: element)
+            searchBar.apply(to: element.searchBar)
+        }
+    }
+}
+
+extension UISearchBar {
+    func setTextInputBackgroundColor(color: UIColor, height: CGFloat, cornerRadius: CGFloat) {
+        // creates an image with rounded corners from background color
+        let size = CGSize(width: cornerRadius * 2, height: height)
+        let backgroundImage = UIGraphicsImageRenderer(size: size)
+            .image { imageContext in
+                let path = UIBezierPath(roundedRect: CGRect(origin: .zero, size: size), cornerRadius: cornerRadius)
+
+                imageContext.cgContext.beginPath()
+                imageContext.cgContext.addPath(path.cgPath)
+                imageContext.cgContext.closePath()
+                imageContext.cgContext.clip()
+
+                imageContext.cgContext.setFillColor(color.cgColor)
+                imageContext.cgContext.fill(CGRect(origin: .zero, size: size))
+            }
+        setSearchFieldBackgroundImage(backgroundImage, for: .normal)
+    }
+}

--- a/BentoKit/BentoKit/Components/Search.swift
+++ b/BentoKit/BentoKit/Components/Search.swift
@@ -20,6 +20,7 @@ extension Component {
                 view.didBeginEditing = didBeginEditing
                 view.textDidChange = textDidChange
                 view.cancelButtonClicked = cancelButtonClicked
+                view.searchBar.height(styleSheet.searchBar.height)
             }
             self.styleSheet = styleSheet
         }
@@ -41,9 +42,6 @@ extension Component.Search {
             searchBar.add(to: self)
                 .pinEdges(to: layoutMarginsGuide)
 
-            searchBar.backgroundColor = .white
-            searchBar.barTintColor = .white
-            searchBar.backgroundImage = UIImage()
             searchBar.delegate = self
         }
 
@@ -72,29 +70,7 @@ extension Component.Search {
 
 extension Component.Search {
     public final class StyleSheet: BaseViewStyleSheet<View> {
-        public struct SearchBar: StyleSheetProtocol {
-            public var backgroundColor: UIColor = .white
-            public var cornerRadius: CGFloat = 10
-            public var height: CGFloat = 36
-            public var showsCancelButton: Bool = false
-            public var searchTextPositionAdjustment: UIOffset = UIOffset.init(horizontal: 8, vertical: 0)
-            public var keyboardType: UIKeyboardType = .default
-            public var returnKeyType: UIReturnKeyType = .search
-            public var enablesReturnKeyAutomatically: Bool = true
-
-            public func apply(to element: UISearchBar) {
-                element.height(height)
-                element.setTextInputBackgroundColor(color: backgroundColor,
-                                                    height: height,
-                                                    cornerRadius: cornerRadius)
-                element.showsCancelButton = showsCancelButton
-                element.searchTextPositionAdjustment = searchTextPositionAdjustment
-                element.keyboardType = keyboardType
-                element.returnKeyType = returnKeyType
-                element.enablesReturnKeyAutomatically = enablesReturnKeyAutomatically
-            }
-        }
-        public var searchBar: SearchBar = SearchBar()
+        public var searchBar = SearchBarStyleSheet()
 
         public init() {}
 
@@ -102,25 +78,5 @@ extension Component.Search {
             super.apply(to: element)
             searchBar.apply(to: element.searchBar)
         }
-    }
-}
-
-extension UISearchBar {
-    func setTextInputBackgroundColor(color: UIColor, height: CGFloat, cornerRadius: CGFloat) {
-        // creates an image with rounded corners from background color
-        let size = CGSize(width: cornerRadius * 2, height: height)
-        let backgroundImage = UIGraphicsImageRenderer(size: size)
-            .image { imageContext in
-                let path = UIBezierPath(roundedRect: CGRect(origin: .zero, size: size), cornerRadius: cornerRadius)
-
-                imageContext.cgContext.beginPath()
-                imageContext.cgContext.addPath(path.cgPath)
-                imageContext.cgContext.closePath()
-                imageContext.cgContext.clip()
-
-                imageContext.cgContext.setFillColor(color.cgColor)
-                imageContext.cgContext.fill(CGRect(origin: .zero, size: size))
-            }
-        setSearchFieldBackgroundImage(backgroundImage, for: .normal)
     }
 }

--- a/BentoKit/BentoKitTests/SnapshotTests/Components/SearchSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/SearchSnapshotTests.swift
@@ -13,7 +13,7 @@ final class SearchSnapshotTests: SnapshotTestCase {
 
     func testSearch() {
         let styleSheet = Component.Search.StyleSheet()
-            .compose(\.searchBar.backgroundColor, UIColor.gray.withAlphaComponent(0.25))
+            .compose(\.searchBar.textInputBackgroundColor, UIColor.gray.withAlphaComponent(0.25))
             .compose(\.searchBar.showsCancelButton, true)
 
         let component = Component.Search(placeholder: placeholder, styleSheet: styleSheet)

--- a/BentoKit/BentoKitTests/SnapshotTests/Components/SearchSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/SearchSnapshotTests.swift
@@ -1,0 +1,24 @@
+import BentoKit
+import StyleSheets
+import UIKit
+@testable import BentoKitPlaygroundSupport
+
+final class SearchSnapshotTests: SnapshotTestCase {
+    let placeholder = "Search for address or a postcode"
+
+    override func setUp() {
+        super.setUp()
+        self.recordMode = false
+    }
+
+    func testSearch() {
+        let styleSheet = Component.Search.StyleSheet()
+            .compose(\.searchBar.backgroundColor, UIColor.gray.withAlphaComponent(0.25))
+            .compose(\.searchBar.showsCancelButton, true)
+
+        let component = Component.Search(placeholder: placeholder, styleSheet: styleSheet)
+
+        verifyComponentForAllSizes(component: component)
+    }
+
+}

--- a/Snapshots/ReferenceImages_64/BentoKitTests.SearchSnapshotTests/testSearch_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.SearchSnapshotTests/testSearch_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad4e8330fb030f9e22f2bef41e8e227e2a48ffcf9329c0cd8d34352c9ed11b67
+size 31686

--- a/Snapshots/ReferenceImages_64/BentoKitTests.SearchSnapshotTests/testSearch_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.SearchSnapshotTests/testSearch_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfa5e222b99047f5e3fc28d19d57f572a1e6c8bf692d87d3858365e378ac493d
+size 36317

--- a/Snapshots/ReferenceImages_64/BentoKitTests.SearchSnapshotTests/testSearch_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.SearchSnapshotTests/testSearch_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da185221d8dc6d2b3a6dc891337f994cb7ec6e2c36d8551e74b58b92d0bb01e8
+size 36824

--- a/StyleSheets/StyleSheets.xcodeproj/project.pbxproj
+++ b/StyleSheets/StyleSheets.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		6554A9ED21369CA900D84BD4 /* TextAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6554A9EC21369CA900D84BD4 /* TextAlignment.swift */; };
 		6554A9F72136A1FB00D84BD4 /* StyleSheets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6554A9D0213699B600D84BD4 /* StyleSheets.framework */; };
 		6554A9FE2136A20B00D84BD4 /* StyleSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6554A9FD2136A20A00D84BD4 /* StyleSheetTests.swift */; };
+		B5BD13022194405400DC6A51 /* SearchBarStyleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BD13012194405400DC6A51 /* SearchBarStyleSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,7 @@
 		A6C9C8DB21807A1D00261906 /* Framework.Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.Debug.xcconfig; sourceTree = "<group>"; };
 		A6C9C8DC21807A1D00261906 /* Framework.Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.Base.xcconfig; sourceTree = "<group>"; };
 		A6C9C8DD21807A1D00261906 /* Framework.Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.Release.xcconfig; sourceTree = "<group>"; };
+		B5BD13012194405400DC6A51 /* SearchBarStyleSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarStyleSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +112,7 @@
 				25EFC89D217BA8390056D4B9 /* TextBoundComputing.swift */,
 				25EFC89F217BA85B0056D4B9 /* TextViewStyleSheet.swift */,
 				25EFC891217BA6450056D4B9 /* ViewStyleSheet.swift */,
+				B5BD13012194405400DC6A51 /* SearchBarStyleSheet.swift */,
 			);
 			path = StyleSheets;
 			sourceTree = "<group>";
@@ -248,6 +251,7 @@
 				25EFC8A2217BA8750056D4B9 /* TableViewStyleSheet.swift in Sources */,
 				25EFC892217BA6450056D4B9 /* ViewStyleSheet.swift in Sources */,
 				25EFC896217BA6830056D4B9 /* LabelStyleSheet.swift in Sources */,
+				B5BD13022194405400DC6A51 /* SearchBarStyleSheet.swift in Sources */,
 				25EFC89E217BA8390056D4B9 /* TextBoundComputing.swift in Sources */,
 				25EFC898217BA6D10056D4B9 /* ButtonStyleSheet.swift in Sources */,
 				25EFC89C217BA8050056D4B9 /* ImageViewStyleSheet.swift in Sources */,

--- a/StyleSheets/StyleSheets/SearchBarStyleSheet.swift
+++ b/StyleSheets/StyleSheets/SearchBarStyleSheet.swift
@@ -1,37 +1,20 @@
 import UIKit
 
 open class SearchBarStyleSheet: ViewStyleSheet<UISearchBar> {
-    public var height: CGFloat
-    public var showsCancelButton: Bool
-    public var searchTextPositionAdjustment: UIOffset
-    public var keyboardType: UIKeyboardType
-    public var returnKeyType: UIReturnKeyType
-    public var enablesReturnKeyAutomatically: Bool
-
-    public init(
-        backgroundColor: UIColor = .white,
-        cornerRadius: CGFloat = 10,
-        height: CGFloat = 36,
-        showsCancelButton: Bool = false,
-        searchTextPositionAdjustment: UIOffset = UIOffset(horizontal: 8, vertical: 0),
-        keyboardType: UIKeyboardType = .default,
-        returnKeyType: UIReturnKeyType = .search,
-        enablesReturnKeyAutomatically: Bool = true
-        ) {
-        self.height = height
-        self.showsCancelButton = showsCancelButton
-        self.searchTextPositionAdjustment = searchTextPositionAdjustment
-        self.keyboardType = keyboardType
-        self.returnKeyType = returnKeyType
-        self.enablesReturnKeyAutomatically = enablesReturnKeyAutomatically
-        super.init(backgroundColor: backgroundColor, cornerRadius: cornerRadius)
-    }
+    public var textInputBackgroundColor: UIColor = .white
+    public var textInputCornerRaidus: CGFloat = 10
+    public var height: CGFloat = 36
+    public var showsCancelButton: Bool = false
+    public var searchTextPositionAdjustment: UIOffset = UIOffset(horizontal: 8, vertical: 0)
+    public var keyboardType: UIKeyboardType = .default
+    public var returnKeyType: UIReturnKeyType = .search
+    public var enablesReturnKeyAutomatically: Bool = true
 
     open override func apply(to element: UISearchBar) {
         super.apply(to: element)
-        element.setTextInputBackgroundColor(color: backgroundColor ?? .clear,
+        element.setTextInputBackgroundColor(color: textInputBackgroundColor,
                                             height: height,
-                                            cornerRadius: cornerRadius)
+                                            cornerRadius: textInputCornerRaidus)
         element.showsCancelButton = showsCancelButton
         element.searchTextPositionAdjustment = searchTextPositionAdjustment
         element.keyboardType = keyboardType
@@ -39,7 +22,6 @@ open class SearchBarStyleSheet: ViewStyleSheet<UISearchBar> {
         element.enablesReturnKeyAutomatically = enablesReturnKeyAutomatically
         element.barTintColor = tintColor
         // remove system background
-        element.backgroundColor = .white
         element.backgroundImage = UIImage()
     }
 

--- a/StyleSheets/StyleSheets/SearchBarStyleSheet.swift
+++ b/StyleSheets/StyleSheets/SearchBarStyleSheet.swift
@@ -1,0 +1,66 @@
+import UIKit
+
+open class SearchBarStyleSheet: ViewStyleSheet<UISearchBar> {
+    public var height: CGFloat
+    public var showsCancelButton: Bool
+    public var searchTextPositionAdjustment: UIOffset
+    public var keyboardType: UIKeyboardType
+    public var returnKeyType: UIReturnKeyType
+    public var enablesReturnKeyAutomatically: Bool
+
+    public init(
+        backgroundColor: UIColor = .white,
+        cornerRadius: CGFloat = 10,
+        height: CGFloat = 36,
+        showsCancelButton: Bool = false,
+        searchTextPositionAdjustment: UIOffset = UIOffset(horizontal: 8, vertical: 0),
+        keyboardType: UIKeyboardType = .default,
+        returnKeyType: UIReturnKeyType = .search,
+        enablesReturnKeyAutomatically: Bool = true
+        ) {
+        self.height = height
+        self.showsCancelButton = showsCancelButton
+        self.searchTextPositionAdjustment = searchTextPositionAdjustment
+        self.keyboardType = keyboardType
+        self.returnKeyType = returnKeyType
+        self.enablesReturnKeyAutomatically = enablesReturnKeyAutomatically
+        super.init(backgroundColor: backgroundColor, cornerRadius: cornerRadius)
+    }
+
+    open override func apply(to element: UISearchBar) {
+        super.apply(to: element)
+        element.setTextInputBackgroundColor(color: backgroundColor ?? .clear,
+                                            height: height,
+                                            cornerRadius: cornerRadius)
+        element.showsCancelButton = showsCancelButton
+        element.searchTextPositionAdjustment = searchTextPositionAdjustment
+        element.keyboardType = keyboardType
+        element.returnKeyType = returnKeyType
+        element.enablesReturnKeyAutomatically = enablesReturnKeyAutomatically
+        element.barTintColor = tintColor
+        // remove system background
+        element.backgroundColor = .white
+        element.backgroundImage = UIImage()
+    }
+
+}
+
+extension UISearchBar {
+    func setTextInputBackgroundColor(color: UIColor, height: CGFloat, cornerRadius: CGFloat) {
+        // creates an image with rounded corners from background color
+        let size = CGSize(width: cornerRadius * 2, height: height)
+        let backgroundImage = UIGraphicsImageRenderer(size: size)
+            .image { imageContext in
+                let path = UIBezierPath(roundedRect: CGRect(origin: .zero, size: size), cornerRadius: cornerRadius)
+
+                imageContext.cgContext.beginPath()
+                imageContext.cgContext.addPath(path.cgPath)
+                imageContext.cgContext.closePath()
+                imageContext.cgContext.clip()
+
+                imageContext.cgContext.setFillColor(color.cgColor)
+                imageContext.cgContext.fill(CGRect(origin: .zero, size: size))
+        }
+        setSearchFieldBackgroundImage(backgroundImage, for: .normal)
+    }
+}


### PR DESCRIPTION
This PR adds a simple component that contains `UISearchBar`. 

### Motivation

Sometimes it might be needed just to display a search bar in the cell without the luggage of `UISearchViewController` which might be hard sometimes to tweak to fit particular UX, and something that requires less customisation than `UITextField` to make it look like `UISearchBar`.

### Alternatives considered

There is currently `TextInput` component in BentoKit but it kind of serves a different purpose and also requires quite some tweaking and style additions to make it fit this use case. Also `UISearchBar` is not a subclass of `UITextField` and have some extra features like showing cancel button and search icon out of the box (still could be done with `TextInput` but not without more changes to it).

`UISearchViewController` also does not fit here very well as it requires `navigationItem` and it can be tricky to make it work with DrawerKit used here (see screenshot)

### Example

![simulator screen shot - iphone xs max - 2018-11-06 at 19 40 20](https://user-images.githubusercontent.com/1488293/48129215-b37ff980-e280-11e8-9aba-5c3e43e10372.png)