### PR TITLE
Fix issue with bar button item not resigning first responder 

### DIFF
--- a/BentoKit/BentoKit/Screen/BoxViewController.swift
+++ b/BentoKit/BentoKit/Screen/BoxViewController.swift
@@ -388,7 +388,7 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
         } else {
             let items = navigationItem[keyPath: itemsKeyPath] ?? []
             for (lhs, rhs) in zip(new, items) {
-                lhs.applyNonAppearanceChanges(to: rhs)
+                lhs.applyNonAppearanceChanges(to: rhs, willTriggerAction: resignFirstResponder)
             }
         }
 

--- a/BentoKit/BentoKit/Screen/Screen.swift
+++ b/BentoKit/BentoKit/Screen/Screen.swift
@@ -132,9 +132,11 @@ public struct BarButtonItem {
         return item
     }
 
-    public func applyNonAppearanceChanges(to item: UIBarButtonItem) {
-        item.didTap = callback
-        item.isEnabled = isEnabled
+    public func applyNonAppearanceChanges(to item: UIBarButtonItem, willTriggerAction: (() -> Void)? = nil) {
+        item.didTap = {
+            willTriggerAction?()
+            self.callback?()
+        }
         item.accessibilityIdentifier = accessibilityIdentifier
     }
 


### PR DESCRIPTION
## Description

There is an issue with BoxView when sometimes it does not resign first responder when bar button pressed leaving any editing that was in progress uncommitted.

## Solution

Make sure we resign first responder before sending bar button actions


