### PR TITLE
Put `isEnabled` back as it was accidentally removed in the last PR

### DIFF
--- a/BentoKit/BentoKit/Screen/Screen.swift
+++ b/BentoKit/BentoKit/Screen/Screen.swift
@@ -137,6 +137,7 @@ public struct BarButtonItem {
             willTriggerAction?()
             self.callback?()
         }
+        item.isEnabled = isEnabled
         item.accessibilityIdentifier = accessibilityIdentifier
     }
 


### PR DESCRIPTION
I accidentally remove isEnabled in #70 [here](https://github.com/Babylonpartners/Bento/pull/70/files#diff-a9970701959e9e78413d9811a47b11bfL137)