### PR TITLE
Option to disable first responder ascension upon interaction.

### DIFF
--- a/BentoKit/BentoKit.xcodeproj/project.pbxproj
+++ b/BentoKit/BentoKit.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		5880119E216272C30084EE07 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5880119D216272C30084EE07 /* Device.swift */; };
 		588011A02162740C0084EE07 /* FBSnapshotTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5880119F2162740C0084EE07 /* FBSnapshotTestCaseExtensions.swift */; };
 		58ADAF72215E602E00B143F5 /* UIImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ADAF71215E602E00B143F5 /* UIImageExtensions.swift */; };
+		65020C3022030CB000DC8F42 /* InteractionBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65020C2F22030CB000DC8F42 /* InteractionBehavior.swift */; };
 		7421E0282192D9B70014F631 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7421E0272192D9B70014F631 /* Resources.swift */; };
 		A6113A7E2180CD0100C6DB5A /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6113A7D2180CD0100C6DB5A /* FBSnapshotTestCase.framework */; };
 		A6EC2DAE218B28AA002B128F /* BoxAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6EC2DA9218B28AA002B128F /* BoxAppearance.swift */; };
@@ -170,6 +171,7 @@
 		588011A321627D570084EE07 /* ReactiveSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReactiveSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		58ADAF71215E602E00B143F5 /* UIImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtensions.swift; sourceTree = "<group>"; };
 		639430F94D2A3AB0B5FBBFF0 /* Pods_BentoKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BentoKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		65020C2F22030CB000DC8F42 /* InteractionBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionBehavior.swift; sourceTree = "<group>"; };
 		7421E0272192D9B70014F631 /* Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resources.swift; sourceTree = "<group>"; };
 		A6113A7A2180C87400C6DB5A /* Framework.Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.Debug.xcconfig; sourceTree = "<group>"; };
 		A6113A7B2180C87400C6DB5A /* Framework.Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.Base.xcconfig; sourceTree = "<group>"; };
@@ -278,6 +280,7 @@
 				580B612B215D2F6800A69E87 /* TitledDescription.swift */,
 				580B6122215D2F6700A69E87 /* Toggle.swift */,
 				B5BD11C5219301D500DC6A51 /* Search.swift */,
+				65020C2F22030CB000DC8F42 /* InteractionBehavior.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -631,6 +634,7 @@
 				580B612E215D2F6800A69E87 /* Component.swift in Sources */,
 				580B614A215D353B00A69E87 /* InputNodes.swift in Sources */,
 				B5BD11C6219301D500DC6A51 /* Search.swift in Sources */,
+				65020C3022030CB000DC8F42 /* InteractionBehavior.swift in Sources */,
 				580B6134215D2F6800A69E87 /* TextInput.swift in Sources */,
 				A6EC2DB0218B28AA002B128F /* BoxViewModel.swift in Sources */,
 				580B611F215D2F6100A69E87 /* HeightCustomizing.swift in Sources */,

--- a/BentoKit/BentoKit/Components/Button.swift
+++ b/BentoKit/BentoKit/Components/Button.swift
@@ -15,6 +15,7 @@ extension Component {
             isEnabled: Bool = true,
             isLoading: Bool = false,
             didTap: (() -> Void)? = nil,
+            interactionBehavior: InteractionBehavior = .becomeFirstResponder,
             styleSheet: StyleSheet
         ) {
             self.configurator = { view in
@@ -22,6 +23,7 @@ extension Component {
                 view.button.isEnabled = isEnabled
                 view.button.setTitle(title, for: .normal)
                 view.didTap = didTap
+                view.interactionBehavior = interactionBehavior
             }
             self.heightComputer = { width, inheritedMargins in
                 let contentWidth = width
@@ -62,6 +64,8 @@ extension Component.Button {
         public let button = Button(type: .system).with {
             $0.setContentHuggingPriority(.required, for: .vertical)
         }
+
+        fileprivate var interactionBehavior: InteractionBehavior = .becomeFirstResponder
 
         private lazy var huggingConstraints: [NSLayoutConstraint] = [
             button.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor)
@@ -123,7 +127,10 @@ extension Component.Button {
         }
 
         @objc private func buttonPressed() {
-            becomeFirstResponder()
+            if interactionBehavior.contains(.becomeFirstResponder) {
+                becomeFirstResponder()
+            }
+
             didTap?()
         }
     }

--- a/BentoKit/BentoKit/Components/Description.swift
+++ b/BentoKit/BentoKit/Components/Description.swift
@@ -19,9 +19,11 @@ extension Component {
                     accessoryIcon: UIImage? = nil,
                     didTap: (() -> Void)? = nil,
                     didTapAccessoryButton: (() -> Void)? = nil,
+                    interactionBehavior: InteractionBehavior = .becomeFirstResponder,
                     styleSheet: StyleSheet) {
             self.configurator = { view in
                 view.textLabel.text = text
+                view.interactionBehavior = interactionBehavior
                 view.didTap = didTap
                 view.didTapAccessoryButton = didTapAccessoryButton
                 view.accessoryButton.isHidden = accessoryIcon == nil
@@ -70,6 +72,8 @@ extension Component.Description {
             $0.addTarget(self, action: #selector(accessoryButtonPressed), for: .touchUpInside)
         }
 
+        fileprivate var interactionBehavior: InteractionBehavior = .becomeFirstResponder
+
         fileprivate var didTap: (() -> Void)? {
             didSet {
                 highlightingGesture.didTap = didTap.map(HighlightingGesture.TapAction.resign)
@@ -101,7 +105,10 @@ extension Component.Description {
         }
 
         @objc private func accessoryButtonPressed() {
-            becomeFirstResponder()
+            if interactionBehavior.contains(.becomeFirstResponder) {
+                becomeFirstResponder()
+            }
+
             didTapAccessoryButton?()
         }
     }

--- a/BentoKit/BentoKit/Components/Image.swift
+++ b/BentoKit/BentoKit/Components/Image.swift
@@ -12,10 +12,12 @@ extension Component {
                     styleSheet: StyleSheet,
                     accessibilityIdentifier: String? = nil,
                     accessoryViewAccessibilityIdentifier: String? = nil,
-                    didTapAccessory: (() -> Void)? = nil) {
+                    didTapAccessory: (() -> Void)? = nil,
+                    interactionBehavior: InteractionBehavior = .becomeFirstResponder) {
             configurator = { view in
                 view.imageView.image = image
                 view.didTapAccessory = didTapAccessory
+                view.interactionBehavior = interactionBehavior
                 view.accessoryButton.isHidden = didTapAccessory == nil
                 view.imageView.accessibilityIdentifier = accessibilityIdentifier
                 view.accessoryButton.accessibilityIdentifier = accessoryViewAccessibilityIdentifier
@@ -32,6 +34,7 @@ extension Component.Image {
         fileprivate let imageView = UIImageView()
         fileprivate let accessoryButton = UIButton(type: .custom)
         var didTapAccessory: (() -> Void)?
+        fileprivate var interactionBehavior: InteractionBehavior = .becomeFirstResponder
 
         public override init(frame: CGRect) {
             super.init(frame: frame)
@@ -60,6 +63,10 @@ extension Component.Image {
 
         @objc
         private func accessoryButtonPressed() {
+            if interactionBehavior.contains(.becomeFirstResponder) {
+                becomeFirstResponder()
+            }
+
             didTapAccessory?()
         }
     }

--- a/BentoKit/BentoKit/Components/InteractionBehavior.swift
+++ b/BentoKit/BentoKit/Components/InteractionBehavior.swift
@@ -1,0 +1,9 @@
+public struct InteractionBehavior: OptionSet {
+    public static let becomeFirstResponder = InteractionBehavior(rawValue: 1 << 1)
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+}

--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -43,7 +43,6 @@ public extension Component {
             image: Property<BentoKit.ImageOrLabel>? = nil,
             accessory: Accessory = .chevron,
             badgeIcon: UIImage? = nil,
-            isEnabled: Bool = true,
             inputNodes: CustomInput? = nil,
             didTap: Optional<() -> Void> = nil,
             didTapAccessory: Optional<() -> Void> = nil,
@@ -76,7 +75,6 @@ public extension Component {
                 image: image,
                 accessory: accessory,
                 badgeIcon: badgeIcon,
-                isEnabled: isEnabled,
                 inputNodes: inputNodes,
                 didTap: didTap,
                 didTapAccessory: didTapAccessory,
@@ -90,10 +88,10 @@ public extension Component {
             image: Property<BentoKit.ImageOrLabel>? = nil,
             accessory: Accessory = .chevron,
             badgeIcon: UIImage? = nil,
-            isEnabled: Bool = true,
             inputNodes: CustomInput? = nil,
             didTap: (() -> Void)? = nil,
             didTapAccessory: (() -> Void)? = nil,
+            interactionBehavior: InteractionBehavior = .becomeFirstResponder,
             styleSheet: StyleSheet = .init()
         ) {
             self.configurator = { view in
@@ -111,11 +109,13 @@ public extension Component {
 
                 view.accessoryView.accessory = accessory
                 view.accessoryView.didTap = didTapAccessory
+                view.accessoryView.interactionBehavior = interactionBehavior
 
                 view.badgeView.imageView.image = badgeIcon
                 view.badgeView.isHidden = badgeIcon == nil
 
                 view.inputNodes = inputNodes
+                view.highlightingGesture.interactionBehavior = interactionBehavior
                 view.highlightingGesture.didTap = inputNodes != nil
                     ? .manual
                     : didTap.map(HighlightingGesture.TapAction.resign)

--- a/BentoKit/BentoKit/Helpers/HighlightingGesture.swift
+++ b/BentoKit/BentoKit/Helpers/HighlightingGesture.swift
@@ -29,6 +29,7 @@ public final class HighlightingGesture: UIGestureRecognizer {
             stylingViewDidChange(from: oldValue, to: stylingView)
         }
     }
+    public var interactionBehavior: InteractionBehavior = .becomeFirstResponder
 
     private var normalColor: UIColor?
     private var startPoint = CGPoint.zero
@@ -61,7 +62,10 @@ public final class HighlightingGesture: UIGestureRecognizer {
         case .ended:
             if let view = view {
                 precondition(view.canBecomeFirstResponder, "`HighlightingGesture` should be used only with views that can become first responder.")
-                view.becomeFirstResponder()
+
+                if interactionBehavior.contains(.becomeFirstResponder) {
+                    view.becomeFirstResponder()
+                }
 
                 switch didTap {
                 case .manual?:

--- a/BentoKit/BentoKit/Views/Accessory.swift
+++ b/BentoKit/BentoKit/Views/Accessory.swift
@@ -13,6 +13,11 @@ public final class AccessoryView: InteractiveView {
         }
     }
 
+    public var interactionBehavior: InteractionBehavior {
+        get { return highlightingGesture.interactionBehavior }
+        set { highlightingGesture.interactionBehavior = newValue }
+    }
+
     private var view: UIView? {
         didSet {
             oldValue?.removeFromSuperview()


### PR DESCRIPTION
In general, as a safe default, we would want all components to call back only after ascending themselves to be the first responder. This allows the first responder (text controls in particular) to first write back the data.

But there are scenarios where such behaviour is unnecessary and causing keyboard animation glitches. For example, when using Bento as an autocompletion list augmenting an input view, this would lead to the input view being undesirably dismissed upon user selecting a suggestion. One might instead want to keep the input view active, so as to allow users to continue typing.

This PR adds the ability to opt out in a variety of BentoKit components to disable such behaviour. It is represented with the new `InteractionBehavior` option set, where the opt-out can be specified as an (empty) set without the `becomeFirstResponder` option.