### PR TITLE
Show search bar cancel button with animation

### DIFF
--- a/BentoKit/BentoKit/Components/Search.swift
+++ b/BentoKit/BentoKit/Components/Search.swift
@@ -11,6 +11,7 @@ extension Component {
             keyboardType: UIKeyboardType = .default,
             didBeginEditing: Optional<(UISearchBar) -> Void> = nil,
             textDidChange: Optional<(UISearchBar, String) -> Void> = nil,
+            showsCancelButton: Bool = false,
             cancelButtonClicked: Optional<(UISearchBar) -> Void> = nil,
             styleSheet: StyleSheet = StyleSheet()
             ) {
@@ -20,6 +21,7 @@ extension Component {
                 view.didBeginEditing = didBeginEditing
                 view.textDidChange = textDidChange
                 view.cancelButtonClicked = cancelButtonClicked
+                view.showsCancelButton = showsCancelButton
                 view.searchBar.height(styleSheet.searchBar.height)
             }
             self.styleSheet = styleSheet
@@ -33,7 +35,14 @@ extension Component.Search {
         let searchBar = UISearchBar()
 
         var textDidChange: Optional<(UISearchBar, String) -> Void> = nil
+
+        var showsCancelButton: Bool = false {
+            didSet {
+                searchBar.setShowsCancelButton(showsCancelButton, animated: true)
+            }
+        }
         var cancelButtonClicked: Optional<(UISearchBar) -> Void> = nil
+
         var didBeginEditing: Optional<(UISearchBar) -> Void> = nil
 
         public override init(frame: CGRect) {

--- a/BentoKit/BentoKitTests/SnapshotTests/Components/SearchSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/SearchSnapshotTests.swift
@@ -14,9 +14,12 @@ final class SearchSnapshotTests: SnapshotTestCase {
     func testSearch() {
         let styleSheet = Component.Search.StyleSheet()
             .compose(\.searchBar.textInputBackgroundColor, UIColor.gray.withAlphaComponent(0.25))
-            .compose(\.searchBar.showsCancelButton, true)
 
-        let component = Component.Search(placeholder: placeholder, styleSheet: styleSheet)
+        let component = Component.Search(
+            placeholder: placeholder,
+            showsCancelButton: true,
+            styleSheet: styleSheet
+        )
 
         verifyComponentForAllSizes(component: component)
     }

--- a/StyleSheets/StyleSheets/SearchBarStyleSheet.swift
+++ b/StyleSheets/StyleSheets/SearchBarStyleSheet.swift
@@ -15,7 +15,7 @@ open class SearchBarStyleSheet: ViewStyleSheet<UISearchBar> {
         element.setTextInputBackgroundColor(color: textInputBackgroundColor,
                                             height: height,
                                             cornerRadius: textInputCornerRaidus)
-        element.showsCancelButton = showsCancelButton
+        element.setShowsCancelButton(showsCancelButton, animated: true)
         element.searchTextPositionAdjustment = searchTextPositionAdjustment
         element.keyboardType = keyboardType
         element.returnKeyType = returnKeyType

--- a/StyleSheets/StyleSheets/SearchBarStyleSheet.swift
+++ b/StyleSheets/StyleSheets/SearchBarStyleSheet.swift
@@ -4,7 +4,6 @@ open class SearchBarStyleSheet: ViewStyleSheet<UISearchBar> {
     public var textInputBackgroundColor: UIColor = .white
     public var textInputCornerRaidus: CGFloat = 10
     public var height: CGFloat = 36
-    public var showsCancelButton: Bool = false
     public var searchTextPositionAdjustment: UIOffset = UIOffset(horizontal: 8, vertical: 0)
     public var keyboardType: UIKeyboardType = .default
     public var returnKeyType: UIReturnKeyType = .search
@@ -15,7 +14,6 @@ open class SearchBarStyleSheet: ViewStyleSheet<UISearchBar> {
         element.setTextInputBackgroundColor(color: textInputBackgroundColor,
                                             height: height,
                                             cornerRadius: textInputCornerRaidus)
-        element.setShowsCancelButton(showsCancelButton, animated: true)
         element.searchTextPositionAdjustment = searchTextPositionAdjustment
         element.keyboardType = keyboardType
         element.returnKeyType = returnKeyType


### PR DESCRIPTION
`SearchBarStyleSheet` applies cancel button without animation, so when screen is re-rendered with this property updated no animation happens in the search bar. This will perform animation by default. But we might want to come up with a more generic solution that could be used for all properties that can be set with animation, i.e. instead of using primitive types like `Bool` here we could introduce something like (not necessary an enum)

```swift
enum AnimatableProperty<T> {
  case withAnimation(T)
  case withoutAnimation(T)
}
```