### PR TITLE
Handle nil IndexPath for `canPerformAction` 

### DIFF
--- a/Bento/Adapters/CollectionViewAdapter.swift
+++ b/Bento/Adapters/CollectionViewAdapter.swift
@@ -113,8 +113,9 @@ open class CollectionViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
     }
 
     @objc(collectionView:canPerformAction:forItemAtIndexPath:withSender:)
-    open func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
-        guard let component = sections[indexPath.section].items[indexPath.row].component(as: MenuItemsResponding.self) else {
+    open func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath?, withSender sender: Any?) -> Bool {
+        guard let indexPath = indexPath,
+            let component = sections[indexPath.section].items[indexPath.row].component(as: MenuItemsResponding.self) else {
             return false
         }
 


### PR DESCRIPTION
## Description

Apparently UIKit may call this method with `nil` `indexPath` via obj which leads to crashes in Swift. So far it was spotted only via UI automation tests

<img width="796" alt="screen shot 2018-11-08 at 14 12 55" src="https://user-images.githubusercontent.com/4622322/48270251-8292f680-e431-11e8-899f-fba4c01abd77.png">

## Solution

Make `indexPath` parameter optional and unwrap it before doing anything