### PR TITLE
Allow providing custom views as accessory

### DIFF
--- a/BentoKit/BentoKit/Components.playground/Pages/TitledDescription.xcplaygroundpage/Contents.swift
+++ b/BentoKit/BentoKit/Components.playground/Pages/TitledDescription.xcplaygroundpage/Contents.swift
@@ -9,6 +9,16 @@ import ReactiveSwift
 let bundle = Bundle(for: Component.TextInput.self)
 let image = UIImage(named: "tickIcon", in: bundle, compatibleWith: nil)!
 
+let button = UIButton(type: .custom)
+button.setTitleColor(UIColor.black, for: .normal)
+button.setTitle("call", for: .normal)
+button.setImage(image, for: .normal)
+
+button.titleEdgeInsets = UIEdgeInsets(top: 37, left: -27, bottom: 0, right: 0)
+button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 7, bottom: 0, right: 0)
+button.heightAnchor.constraint(equalToConstant: 58).isActive = true
+button.widthAnchor.constraint(equalToConstant: 37).isActive = true
+
 let component = Component.TitledDescription(
     texts: [
         TextValue.plain("Text 1"),
@@ -18,7 +28,7 @@ let component = Component.TitledDescription(
     ],
     detail: TextValue.plain("Detail"),
     image: Property(value: ImageOrLabelView.Content.image(image)),
-    accessory: Component.TitledDescription.Accessory.checkmark,
+    accessory: Component.TitledDescription.Accessory.custom(button),
     isEnabled: true,
     didTap: {
         print("didTap")
@@ -29,7 +39,8 @@ let component = Component.TitledDescription(
     deleteAction: .action(title: "Delete") {
         print("didDelete")
     },
-    styleSheet: Component.TitledDescription.StyleSheet(textStyles: [
+    styleSheet: Component.TitledDescription.StyleSheet(
+        textStyles: [
         .init(),
         .init(),
         .init(),

--- a/BentoKit/BentoKit/Components.playground/Pages/TitledDescription.xcplaygroundpage/timeline.xctimeline
+++ b/BentoKit/BentoKit/Components.playground/Pages/TitledDescription.xcplaygroundpage/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -206,6 +206,13 @@ private extension Component.TitledDescription {
                 detailWidthPlusSpacing = 0
             }
 
+            let accessorySize: CGSize
+            if case let .custom(view) = accessory {
+                view.layoutIfNeeded()
+                accessorySize = view.frame.size
+            } else {
+                accessorySize = CGSize(width: 24, height: 24)
+            }
             let availableWidthForLabelBlock = width
                 - max(styleSheet.layoutMargins.left, inheritedMargins.left)
                 - max(styleSheet.layoutMargins.right, inheritedMargins.right)
@@ -214,7 +221,7 @@ private extension Component.TitledDescription {
                     : 0)
                 - imageWidthPlusSpacing(measuring: image, styleSheet: styleSheet)
                 - detailWidthPlusSpacing
-                - (accessory != .none ? 24 + xSpacing : 0)
+                - (accessory != .none ? accessorySize.width + xSpacing : 0)
 
             assert(availableWidthForLabelBlock > 0,
                    "availableWidthForLabelBlock (\(availableWidthForLabelBlock)) ≤ 0")
@@ -235,7 +242,8 @@ private extension Component.TitledDescription {
                 verticalMargins + max(
                     textHeightsPlusSpacing,
                     styleSheet.imageOrLabel.fixedSize?.height ?? 0,
-                    detailHeight
+                    detailHeight,
+                    accessorySize.height
                 ),
                 styleSheet.enforcesMinimumHeight ? 44 : 0
             )

--- a/BentoKit/BentoKit/Views/Accessory.swift
+++ b/BentoKit/BentoKit/Views/Accessory.swift
@@ -42,6 +42,10 @@ public final class AccessoryView: InteractiveView {
     }
 
     public override var intrinsicContentSize: CGSize {
+        if case let .custom(view) = accessory {
+            view.layoutIfNeeded()
+            return view.frame.size
+        }
         return CGSize(width: 24, height: 24)
     }
 
@@ -63,6 +67,8 @@ public final class AccessoryView: InteractiveView {
         case let .tintedIcon(image, tintColor):
             view = UIImageView(image: image)
                 .with { $0.tintColor = tintColor }
+        case let .custom(customView):
+            view = customView
         case .none:
             view = nil
         }
@@ -77,6 +83,7 @@ extension AccessoryView {
         case checkmark
         case icon(UIImage)
         case tintedIcon(UIImage, UIColor)
+        case custom(UIView)
         case none
     }
 }

--- a/BentoKit/BentoKitTests/SnapshotTests/Components/TitledDescriptionSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/TitledDescriptionSnapshotTests.swift
@@ -115,6 +115,36 @@ final class TitledDescriptionSnapshotTests: SnapshotTestCase {
         verifyComponentForAllSizes(component: component)
     }
 
+    func test_with_custom_accessory_view() {
+        let image = UIImageView(image: self.image(named: "plus"))
+        image.backgroundColor = .red
+        image.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        image.widthAnchor.constraint(equalToConstant: 50).isActive = true
+
+        let component = Component.TitledDescription(
+            texts: [.plain("Title"), .plain("Label 4 is also a fine label but definitely far too long to be considered a good label")],
+            detail: .plain("Detail"),
+            accessory: .custom(image),
+            styleSheet: styleSheet(2))
+
+        verifyComponentForAllSizes(component: component)
+    }
+
+    func test_considers_custom_accessory_view_size() {
+        let image = UIImageView(image: self.image(named: "plus"))
+        image.backgroundColor = .red
+        image.heightAnchor.constraint(equalToConstant: 150).isActive = true
+        image.widthAnchor.constraint(equalToConstant: 50).isActive = true
+
+        let component = Component.TitledDescription(
+            texts: [.plain("Title"), .plain("Label 4 is also a fine label but definitely far too long to be considered a good label")],
+            detail: .plain("Detail"),
+            accessory: .custom(image),
+            styleSheet: styleSheet(2))
+
+        verifyComponentForAllSizes(component: component)
+    }
+
     func test_has_image_fixed_size() {
         let component = Component.TitledDescription(
             texts: [.plain("Title"), .plain("Subtitle")],

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_considers_custom_accessory_view_size_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_considers_custom_accessory_view_size_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdcd81e67ffb23182fafedf63bf95b2c3f56917e46e17c1fc05e5a0822f9ae45
+size 43257

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_considers_custom_accessory_view_size_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_considers_custom_accessory_view_size_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f814327ccc311bddf7fbe81061d7ecc2ecb3d0c431f7a34beca6bc7a8f6baee
+size 47278

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_considers_custom_accessory_view_size_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_considers_custom_accessory_view_size_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7edd751b9612599fcc76d18e81bdc84ba1f25c092bd956fcb6ce0d4cc6a591e
+size 47688

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_with_custom_accessory_view_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_with_custom_accessory_view_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c290aff6dce590c70e584807a44f92028ac08c7388becb66da9bbc5764f45387
+size 41774

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_with_custom_accessory_view_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_with_custom_accessory_view_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0aa26b7740b31d8ca7380fb21ea5542d47e2cf33045994176991373c4f4995b
+size 46025

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_with_custom_accessory_view_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_with_custom_accessory_view_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1320accaaa934b05f7c64c56e34b935b0fdc154a3bfbda23fae6ab8a6ff074f6
+size 46794


### PR DESCRIPTION
This will allow to provide a custom view, i.e. button, as accessory view. Here it's a button with "call" title and icon on the right side.

<img width="373" alt="screen shot 2018-11-15 at 18 21 57" src="https://user-images.githubusercontent.com/1488293/48573186-5f6db880-e903-11e8-8804-5aa0d4c5e154.png">
