### PR TITLE
Refactor TitledDescription styling

### DIFF
--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -538,7 +538,7 @@ public extension Component.TitledDescription {
         }
     }
 
-    public final class StyleSheet: BaseViewStyleSheet<View> {
+    public final class StyleSheet: InteractiveViewStyleSheet<View> {
 
         public enum HighlightingTarget {
             case container

--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -509,19 +509,18 @@ private extension Component.TitledDescription.View {
 
 public extension Component.TitledDescription {
     public final class ContentStyleSheet: ViewStyleSheet<BaseStackView> {
+        public typealias Alignment = UIStackView.Alignment
+
         public var spacing: CGFloat
-        public var distribution: UIStackView.Distribution
-        public var alignment: UIStackView.Alignment
+        public var alignment: Alignment
         public var isLayoutMarginsRelativeArrangement: Bool
 
         public init(
             spacing: CGFloat = 16,
-            distribution: UIStackView.Distribution = .fill,
-            alignment: UIStackView.Alignment = .center,
+            alignment: Alignment = .center,
             isLayoutMarginsRelativeArrangement: Bool = false
             ) {
             self.spacing = spacing
-            self.distribution = distribution
             self.alignment = alignment
             self.isLayoutMarginsRelativeArrangement = isLayoutMarginsRelativeArrangement
         }
@@ -529,7 +528,6 @@ public extension Component.TitledDescription {
         public override func apply(to element: BaseStackView) {
             super.apply(to: element)
             element.spacing = spacing
-            element.distribution = distribution
             element.alignment = alignment
             element.isLayoutMarginsRelativeArrangement = isLayoutMarginsRelativeArrangement
             element.cornerRadius = cornerRadius

--- a/BentoKit/BentoKit/Views/BaseView.swift
+++ b/BentoKit/BentoKit/Views/BaseView.swift
@@ -65,7 +65,8 @@ open class BaseStackView: UIStackView, BaseViewProtocol {
     }
 
     private var minimumHeightConstraint: NSLayoutConstraint!
-    private lazy var backgroundView: UIView = {
+    
+    fileprivate lazy var backgroundView: UIView = {
         let view = UIView()
 
         insertSubview(view, at: 0)
@@ -80,6 +81,24 @@ open class BaseStackView: UIStackView, BaseViewProtocol {
         }
         set {
             backgroundView.backgroundColor = newValue
+        }
+    }
+
+    public var borderColor: CGColor? {
+        get {
+            return backgroundView.layer.borderColor
+        }
+        set {
+            backgroundView.layer.borderColor = newValue
+        }
+    }
+
+    public var borderWidth: CGFloat {
+        get {
+            return backgroundView.layer.borderWidth
+        }
+        set {
+            backgroundView.layer.borderWidth = newValue
         }
     }
 


### PR DESCRIPTION
## Why

I need to be able to make `TitledDescription` to look like this:

<img width="375" alt="screenshot 2018-11-16 at 14 48 27" src="https://user-images.githubusercontent.com/4622322/48628306-bc727880-e9ae-11e8-82f4-dbf2f0af17d0.png">

## How

- Added `content` stylesheet to the `TitledDescription.Stylesheet`
- Remove all related properties of the content and use `content` stylesheet
- Add `borderWidth` and `borderColor` properties to the `BaseStackView`


 