### PR TITLE
Fix possible autolayout loop when using an ImageOrLabel/TitledDescription component in a section header

### DIFF
--- a/BentoKit/BentoKit/Views/ImageOrLabelView.swift
+++ b/BentoKit/BentoKit/Views/ImageOrLabelView.swift
@@ -109,6 +109,7 @@ public extension Reactive where Base: ImageOrLabelView {
 private extension ImageOrLabelView {
 
     func setup() {
+        insetsLayoutMarginsFromSafeArea = false
         backgroundColor = .clear
         label.add(to: self).pinEdges(to: self)
         imageView.add(to: self).pinEdges(to: layoutMarginsGuide)

--- a/BentoKit/BentoKit/Views/ImageOrLabelView.swift
+++ b/BentoKit/BentoKit/Views/ImageOrLabelView.swift
@@ -109,7 +109,9 @@ public extension Reactive where Base: ImageOrLabelView {
 private extension ImageOrLabelView {
 
     func setup() {
-        insetsLayoutMarginsFromSafeArea = false
+        if #available(iOS 11, *) {
+            insetsLayoutMarginsFromSafeArea = false
+        }
         backgroundColor = .clear
         label.add(to: self).pinEdges(to: self)
         imageView.add(to: self).pinEdges(to: layoutMarginsGuide)


### PR DESCRIPTION
This PR fixes an issue where some (very specific) scenarios would create an autolayout loop and freeze the app.

From what I understand of the loop, it appears to be caused by `ImageOrLabelView` extending outside of the safe area. This triggers a resize of the imageOrLabelView, which causes a hierarchy-wide reshuffle. This loops infinitely and causes any application to lock.

Here is the debug output from the `UIViewLayoutFeedbackLoopDebuggingThreshold` launch argument:
```
2018-11-19 11:39:05.213382+0000 Babylon[74990:14118052] [LayoutLoop] Degenerate layout! Layout feedback loop detected in subtree of <_UITableViewHeaderFooterContentView: 0x11fd36270; frame = (0 0; 375 64); wants auto layout; hosts layout engine; tAMIC = YES; >. 

Top-level view = <_UITableViewHeaderFooterContentView: 0x11fd36270; frame = (0 0; 375 64); wants auto layout; hosts layout engine; tAMIC = YES; >

Views caught in loop: 
8 <_UITableViewHeaderFooterContentView: 0x11fd36270; frame = (0 0; 375 64); wants auto layout; hosts layout engine; tAMIC = YES; >
|   1 <TitledDescriptionView: 0x11fd36630; frame = (0 0; 375 64); wants auto layout; tAMIC = NO; >
|   |   4 <BentoKit.BaseStackView: 0x11fd368e0; baseClass = UIStackView; frame = (16 32; 343 24); wants auto layout; tAMIC = NO; >
|   |   |   <UIView: 0x11d3687e0; frame = (0 0; 343 24); wants auto layout; tAMIC = NO; >
|   |   |   5 <BentoKit.ImageOrLabelView: 0x11fd36b00; frame = (0 2; 0 20.5); wants auto layout; tAMIC = NO; >
|   |   |   |   7 <UILabel: 0x11fd36d20; frame = (0 0; 0 8.5); wants auto layout; tAMIC = NO; >
|   |   |   |   6 <UIImageView: 0x11d366820; frame = (0 0; 0 0); wants auto layout; tAMIC = NO; >
|   |   |   <UIStackView: 0x11d367980; frame = (0 0; 343 24); wants auto layout; tAMIC = NO; >
|   |   |   |   <UILabel: 0x11d3673a0; frame = (0 0; 58 24); text = 'About'; wants auto layout; tAMIC = NO; >
|   |   |   |   <UILabel: 0x11d367690; frame = (0 24; 0 0); wants auto layout; tAMIC = NO; >
|   |   |   <UILabel: 0x11d366a50; frame = (343 12; 0 0); wants auto layout; tAMIC = NO; >
|   |   |   <BentoKit.AccessoryView: 0x11d367170; frame = (343 0; 24 24); wants auto layout; tAMIC = NO; >
|   |   2 <_TtCCCO8BentoKit9Component17TitledDescription4ViewP33_EE75C7FE6017E49AEF71599B5636213E9BadgeView: 0x11d366d40; frame = (10 48.5; 12 12); wants auto layout; tAMIC = NO; >
|   |   |   3 <UIImageView: 0x11d366f40; frame = (0 0; 12 12); wants auto layout; tAMIC = NO; >

Views receiving layout in order: (
	<TitledDescriptionView: 0x11fd36630; frame = (0 0; 375 64); wants auto layout; tAMIC = NO; >
	<_TtCCCO8BentoKit9Component17TitledDescription4ViewP33_EE75C7FE6017E49AEF71599B5636213E9BadgeView: 0x11d366d40; frame = (10 48.5; 12 12); wants auto layout; tAMIC = NO; >
	<UIImageView: 0x11d366f40; frame = (0 0; 12 12); wants auto layout; tAMIC = NO; >
	<BentoKit.BaseStackView: 0x11fd368e0; baseClass = UIStackView; frame = (16 32; 343 24); wants auto layout; tAMIC = NO; >
	<BentoKit.ImageOrLabelView: 0x11fd36b00; frame = (0 2; 0 20.5); wants auto layout; tAMIC = NO; >
	<UIImageView: 0x11d366820; frame = (0 0; 0 0); wants auto layout; tAMIC = NO; >
	<UILabel: 0x11fd36d20; frame = (0 0; 0 8.5); wants auto layout; tAMIC = NO; >
	<_UITableViewHeaderFooterContentView: 0x11fd36270; frame = (0 0; 375 64); wants auto layout; hosts layout engine; tAMIC = YES; >
)
```

To prevent `imageOrLabelView` from resizing (which is done because its margins extend outside of the safe area) we can change `insetsLayoutMarginsFromSafeArea` which leaves the margins as they are if we extend out of the safe area.