### PR TITLE
Composable StyleSheet

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		58FC4449207CFBD700DA3614 /* IconTitleDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FC443F207CFBD700DA3614 /* IconTitleDetailsView.swift */; };
 		5B02B99322503A370089371A /* AdapterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B02B99122503A370089371A /* AdapterProtocol.swift */; };
 		5B02B99422503A370089371A /* AdapterStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B02B99222503A370089371A /* AdapterStore.swift */; };
+		5B2CA2A922692E460046D712 /* StyleSheetProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2CA2A822692E460046D712 /* StyleSheetProtocol.swift */; };
+		5B2CA2AB22692E870046D712 /* LegacyStyleSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2CA2AA22692E870046D712 /* LegacyStyleSheetTests.swift */; };
 		5B6807942266818F006AA479 /* SizeCachingTableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6807932266818F006AA479 /* SizeCachingTableViewTests.swift */; };
 		61B40919208523F60063DE25 /* FoodListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B40916208523F50063DE25 /* FoodListViewModel.swift */; };
 		61B64BB12086561B0092082C /* FoodListRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B64BB02086561B0092082C /* FoodListRenderer.swift */; };
@@ -259,6 +261,8 @@
 		5B02B99122503A370089371A /* AdapterProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdapterProtocol.swift; sourceTree = "<group>"; };
 		5B02B99222503A370089371A /* AdapterStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdapterStore.swift; sourceTree = "<group>"; };
 		5B175A6421C0634800590F34 /* ComponentContract.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ComponentContract.md; sourceTree = "<group>"; };
+		5B2CA2A822692E460046D712 /* StyleSheetProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleSheetProtocol.swift; sourceTree = "<group>"; };
+		5B2CA2AA22692E870046D712 /* LegacyStyleSheetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyStyleSheetTests.swift; sourceTree = "<group>"; };
 		5B6807932266818F006AA479 /* SizeCachingTableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeCachingTableViewTests.swift; sourceTree = "<group>"; };
 		61B40916208523F50063DE25 /* FoodListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoodListViewModel.swift; sourceTree = "<group>"; };
 		61B40917208523F50063DE25 /* FoodListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoodListViewController.swift; sourceTree = "<group>"; };
@@ -584,6 +588,7 @@
 				7448E82A2266212B0036B2D6 /* SnapshotTests */,
 				653D460A2256665000CF3E4C /* AdapterStoreTests.swift */,
 				7448E8722266429D0036B2D6 /* StyleSheetTests.swift */,
+				5B2CA2AA22692E870046D712 /* LegacyStyleSheetTests.swift */,
 				9A3EF77F205D866F00D043AC /* AnyRenderableTests.swift */,
 				740921B520ACDDDA00B59F5C /* IfTests.swift */,
 				740921B720ACE5EC00B59F5C /* ConcatenationTests.swift */,
@@ -733,12 +738,13 @@
 		7448E8572266425F0036B2D6 /* StyleSheets */ = {
 			isa = PBXGroup;
 			children = (
+				7448E85C2266427F0036B2D6 /* StyleSheet.swift */,
+				5B2CA2A822692E460046D712 /* StyleSheetProtocol.swift */,
 				7448E85E2266427F0036B2D6 /* ActivityIndicatorStyleSheet.swift */,
 				7448E860226642800036B2D6 /* ButtonStyleSheet.swift */,
 				7448E863226642810036B2D6 /* ImageViewStyleSheet.swift */,
 				7448E85F226642800036B2D6 /* LabelStyleSheet.swift */,
 				7448E85D2266427F0036B2D6 /* StackViewStyleSheet.swift */,
-				7448E85C2266427F0036B2D6 /* StyleSheet.swift */,
 				7448E864226642820036B2D6 /* TableViewStyleSheet.swift */,
 				7448E85A2266427E0036B2D6 /* TextAlignment.swift */,
 				7448E8592266427E0036B2D6 /* TextBoundComputing.swift */,
@@ -1113,6 +1119,7 @@
 				61B64BB6208745730092082C /* CollectionViewContainerCell.swift in Sources */,
 				7448E827226619500036B2D6 /* BentoTableView.swift in Sources */,
 				7448E867226642820036B2D6 /* TextAlignment.swift in Sources */,
+				5B2CA2A922692E460046D712 /* StyleSheetProtocol.swift in Sources */,
 				7448E7D722660A6C0036B2D6 /* Description.swift in Sources */,
 				7448E80622660E920036B2D6 /* ListPickerAdapter.swift in Sources */,
 				65E3ECA2211317EA00869DF3 /* FocusCoordinator.swift in Sources */,
@@ -1156,6 +1163,7 @@
 				5B6807942266818F006AA479 /* SizeCachingTableViewTests.swift in Sources */,
 				651E75C0221005E300130866 /* UIKitContainerDiffApplicationTests.swift in Sources */,
 				7448E8432266220C0036B2D6 /* ImageComponentSnapshotTests.swift in Sources */,
+				5B2CA2AB22692E870046D712 /* LegacyStyleSheetTests.swift in Sources */,
 				7448E833226621BF0036B2D6 /* Device.swift in Sources */,
 				7448E834226621BF0036B2D6 /* HostWindow.swift in Sources */,
 				7448E8442266220C0036B2D6 /* TextInputSnapshotTests.swift in Sources */,

--- a/Bento/StyleSheets/StyleSheet.swift
+++ b/Bento/StyleSheets/StyleSheet.swift
@@ -4,41 +4,46 @@ import Foundation
 public struct StyleSheet<View>: Equatable {
     public typealias Inverse = StyleSheet<View>
     
-    private var nodes: [AnyPartialWritableKeyPath: Any]
+    private var entries: [EntryKey: Any]
+    private var orderedKeys: [EntryKey]
 
     public init() {
-        nodes = [:]
+        entries = [:]
+        orderedKeys = []
     }
 
     @discardableResult
     public func apply(to view: inout View) -> Inverse {
-        defer {
-            nodes.forEach { keyPath, value in keyPath.wrapped.apply(to: &view, erasedValue: value) }
+        // NOTE: To handle entries with partially overlapping key paths correctly, we apply changes based on the
+        //       insertion order, and produce an inverse that applies in the reversed insertion order.
+        var inverse = StyleSheet()
+        inverse.orderedKeys = orderedKeys.reversed()
+
+        for key in orderedKeys {
+            inverse.entries[key] = key.keyPath.current(in: view)
+            key.keyPath.unsafeApply(to: &view, erasedValue: entries[key]!)
         }
-        
-        return StyleSheet().with {
-            $0.nodes = Dictionary(
-                uniqueKeysWithValues: self.nodes
-                    .map { keyPath, value in (keyPath, keyPath.wrapped.current(in: view)) }
-            )
-        }
+
+        return inverse
     }
 
     /// Retrieve the value at the specific key path.
     public func value<Value: Equatable>(for keyPath: WritableKeyPath<View, Value>) -> Value? {
-        let keyPath = AnyPartialWritableKeyPath(keyPath)
-        return nodes[keyPath] as! Value?
+        let key = EntryKey(keyPath)
+        return entries[key] as! Value?
     }
-    
-    // `with` + `set` leads to less transient CoW dictionary allocation.
-    /// Set the specified key path to the given value.
+
     public mutating func set<Value: Equatable>(_ keyPath: WritableKeyPath<View, Value>, _ newValue: Value) {
-        let keyPath = AnyPartialWritableKeyPath(keyPath)
-        nodes[keyPath] = newValue
+        let key = EntryKey(keyPath)
+        entries[key] = newValue
+        orderedKeys.append(key)
     }
 
     public mutating func removeValue<Value: Equatable>(for keyPath: WritableKeyPath<View, Value>) {
-        nodes.removeValue(forKey: AnyPartialWritableKeyPath(keyPath))
+        let key = EntryKey(keyPath)
+        if entries.removeValue(forKey: key) != nil {
+            orderedKeys.remove(at: orderedKeys.index(of: key)!)
+        }
     }
     
     public func with(_ action: (inout StyleSheet<View>) -> Void) -> StyleSheet<View> {
@@ -52,43 +57,83 @@ public struct StyleSheet<View>: Equatable {
     }
 
     public static func == (lhs: StyleSheet<View>, rhs: StyleSheet<View>) -> Bool {
-        return lhs.nodes.keys == rhs.nodes.keys
-            && lhs.nodes.keys.allSatisfy { keyPath in
-                keyPath.wrapped.areEqual(lhs.nodes[keyPath]!, rhs.nodes[keyPath]!)
+        return lhs.orderedKeys == rhs.orderedKeys
+            && lhs.orderedKeys.allSatisfy { key in
+                // NOTE: Key paths are equal only when both types and the path completely match. So at this point
+                //       invoking `unsafeAreEqual` on either side should not matter, as they are both of the same type.
+                key.keyPath.unsafeAreEqual(lhs.entries[key]!, rhs.entries[key]!)
             }
     }
 }
 
-private struct AnyPartialWritableKeyPath: Hashable {
-    let wrapped: PartialWritableKeyPath
+/// A wrapper enabling `UnsafePartialWritableKeyPath` to be used as `Dictionary` keys.
+private struct EntryKey: Hashable {
+    let keyPath: UnsafePartialWritableKeyPath
 
-    init(_ wrapped: PartialWritableKeyPath) {
-        self.wrapped = wrapped
+    init(_ keyPath: UnsafePartialWritableKeyPath) {
+        self.keyPath = keyPath
     }
 
-    static func == (lhs: AnyPartialWritableKeyPath, rhs: AnyPartialWritableKeyPath) -> Bool {
-        return lhs.wrapped.keyPath == rhs.wrapped.keyPath
+    static func == (lhs: EntryKey, rhs: EntryKey) -> Bool {
+        return lhs.keyPath.keyPath == rhs.keyPath.keyPath
     }
 
     func hash(into hasher: inout Hasher) {
-        wrapped.keyPath.hash(into: &hasher)
+        keyPath.hash(into: &hasher)
     }
 }
 
-private protocol PartialWritableKeyPath {
+/// Represent a writable key path that has both its root type and its value type erased.
+private protocol UnsafePartialWritableKeyPath: AnyObject {
     var keyPath: AnyKeyPath { get }
 
-    func apply<AssertedRoot>(to root: inout AssertedRoot, erasedValue: Any)
+    /// Partially mutate the given instance at the key path, i.e. `self`, with the given value.
+    ///
+    /// - precondition:
+    ///   - Function parameter `erasedValue` must be a value of the erased value type of the key path.
+    ///   - Type parameter `AssertedRoot` must be the erased root type of the key path.
+    ///
+    /// - parameters:
+    ///   - root: The instance to mutate.
+    ///   - erasedValue: The value to apply at the key path, i.e. `self`.
+    func unsafeApply<AssertedRoot>(to root: inout AssertedRoot, erasedValue: Any)
+
+    /// Read the current value at the key path, i.e. `self`, in the given instance.
+    ///
+    /// - precondition:
+    ///   - Type parameter `AssertedRoot` must be the erased root type of the key path.
+    ///
+    /// - parameters:
+    ///   - root: The instance to read from.
+    ///
+    /// - returns: The current value at the key path, type erased.
     func current<AssertedRoot>(in root: AssertedRoot) -> Any
-    func areEqual(_ lhs: Any, _ rhs: Any) -> Bool
+
+    /// Evaluate whether two values are equal to each other.
+    ///
+    /// - precondition:
+    ///   - Function parameters `lhs` and `rhs` must be a value of the erased value type of the key path.
+    ///
+    /// - parameters:
+    ///   - lhs: The first value to evaluate.
+    ///   - rhs: The second value to evaluate.
+    ///
+    /// - returns: `true` if they are equal. `false` otherwise.
+    func unsafeAreEqual(_ lhs: Any, _ rhs: Any) -> Bool
+
+    /// Hash the key path into the given hasher.
+    ///
+    /// - paramters:
+    ///   - hasher: The hasher to hash into.
+    func hash(into hasher: inout Hasher)
 }
 
-extension WritableKeyPath: PartialWritableKeyPath where Value: Equatable {
+extension WritableKeyPath: UnsafePartialWritableKeyPath where Value: Equatable {
     var keyPath: AnyKeyPath {
         return self
     }
 
-    func apply<AssertedRoot>(to root: inout AssertedRoot, erasedValue: Any) {
+    func unsafeApply<AssertedRoot>(to root: inout AssertedRoot, erasedValue: Any) {
         root[keyPath: coerced()] = erasedValue as! Value
     }
 
@@ -96,12 +141,8 @@ extension WritableKeyPath: PartialWritableKeyPath where Value: Equatable {
         return root[keyPath: coerced()]
     }
 
-    func areEqual(_ lhs: Any, _ rhs: Any) -> Bool {
-        guard let lhs = lhs as? Value, let rhs = rhs as? Value else {
-            return false
-        }
-
-        return lhs == rhs
+    func unsafeAreEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+        return (lhs as! Value) == (rhs as! Value)
     }
 
     private func coerced<AssertedRoot>() -> WritableKeyPath<AssertedRoot, Value> {

--- a/Bento/StyleSheets/StyleSheet.swift
+++ b/Bento/StyleSheets/StyleSheet.swift
@@ -35,8 +35,12 @@ public struct StyleSheet<View>: Equatable {
 
     public mutating func set<Value: Equatable>(_ keyPath: WritableKeyPath<View, Value>, _ newValue: Value) {
         let key = EntryKey(keyPath)
+        let hasInserted = entries.keys.contains(key)
         entries[key] = newValue
-        orderedKeys.append(key)
+
+        if hasInserted.isFalse {
+            orderedKeys.append(key)
+        }
     }
 
     public mutating func removeValue<Value: Equatable>(for keyPath: WritableKeyPath<View, Value>) {

--- a/Bento/StyleSheets/StyleSheet.swift
+++ b/Bento/StyleSheets/StyleSheet.swift
@@ -1,22 +1,95 @@
-import UIKit
+import Foundation
 
-///Protocol for StyleSheets to allow using `compose()` to modify it's value using KeyPaths
-public protocol StyleSheetProtocol {
-    associatedtype Element
+/// Represent a bunch of properties to be applied to the given view.
+public struct StyleSheet<View>: Equatable {
+    public typealias Inverse = StyleSheet<View>
+    
+    private var nodes: [PartialKeyPath<View>: ErasedProperty<View>]
 
-    func apply(to element: Element)
-}
-
-extension StyleSheetProtocol {
-    @discardableResult
-    public func compose<T>(_ property: ReferenceWritableKeyPath<Self, T>, _ value: T) -> Self {
-        self[keyPath: property] = value
-        return self
+    public init() {
+        nodes = [:]
     }
 
     @discardableResult
-    public func compose<T>(_ property: ReferenceWritableKeyPath<Self, T?>, _ value: T?) -> Self {
-        self[keyPath: property] = value
-        return self
+    public func apply(to view: inout View) -> Inverse {
+        defer {
+            nodes.forEach { $0.value.apply(to: &view) }
+        }
+        
+        return StyleSheet().with {
+            $0.nodes = self.nodes.mapValues { $0.current(in: view) }
+        }
+    }
+
+    /// Retrieve the value at the specific key path.
+    public func value<Value: Equatable>(for keyPath: WritableKeyPath<View, Value>) -> Value? {
+        return (nodes[keyPath] as! KeyedProperty<View, Value>?)?.value
+    }
+    
+    // `with` + `set` leads to less transient CoW dictionary allocation.
+    /// Set the specified key path to the given value.
+    public mutating func set<Value: Equatable>(_ keyPath: WritableKeyPath<View, Value>, _ newValue: Value) {
+        nodes[keyPath] = KeyedProperty(keyPath: keyPath, value: newValue)
+    }
+
+    public mutating func removeValue<Value>(for keyPath: WritableKeyPath<View, Value>) {
+        nodes.removeValue(forKey: keyPath)
+    }
+    
+    public func with(_ action: (inout StyleSheet<View>) -> Void) -> StyleSheet<View> {
+        var newSheet = self
+        action(&newSheet)
+        return newSheet
+    }
+    
+    public func setting<Value: Equatable>(_ keyPath: WritableKeyPath<View, Value>, _ value: Value) -> StyleSheet<View> {
+        return with { $0.set(keyPath, value) }
+    }
+}
+
+/// Represent a typed value pending application in a style sheet.
+private final class KeyedProperty<Root, Value: Equatable>: ErasedProperty<Root> {
+    let keyPath: WritableKeyPath<Root, Value>
+    let value: Value
+    
+    init(keyPath: WritableKeyPath<Root, Value>, value: Value) {
+        self.keyPath = keyPath
+        self.value = value
+    }
+    
+    override func apply(to root: inout Root) {
+        root[keyPath: keyPath] = value
+    }
+    
+    override func current(in root: Root) -> Self {
+        return type(of: self).init(keyPath: keyPath, value: root[keyPath: keyPath])
+    }
+    
+    override func equal(to other: ErasedProperty<Root>) -> Bool {
+        guard let other = other as? KeyedProperty<Root, Value>, keyPath == other.keyPath else {
+            return false
+        }
+        
+        return value == other.value
+    }
+}
+
+/// Value-type-erased base class of `KeyedProperty`, allowing style sheets to carry
+/// and manipulate collections of heterogeneous values.
+private class ErasedProperty<Root>: Equatable {
+    func apply(to root: inout Root) {
+        fatalError()
+    }
+    
+    func equal(to other: ErasedProperty<Root>) -> Bool {
+        fatalError()
+    }
+    
+    func current(in root: Root) -> Self {
+        fatalError()
+    }
+    
+    static func == (lhs: ErasedProperty<Root>, rhs: ErasedProperty<Root>) -> Bool {
+        return lhs.equal(to: rhs)
     }
 }

--- a/Bento/StyleSheets/StyleSheetProtocol.swift
+++ b/Bento/StyleSheets/StyleSheetProtocol.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+public protocol StyleSheetProtocol {
+    associatedtype Element
+
+    func apply(to element: Element)
+}
+
+extension StyleSheetProtocol {
+    @discardableResult
+    public func compose<T>(_ property: ReferenceWritableKeyPath<Self, T>, _ value: T) -> Self {
+        self[keyPath: property] = value
+        return self
+    }
+
+    @discardableResult
+    public func compose<T>(_ property: ReferenceWritableKeyPath<Self, T?>, _ value: T?) -> Self {
+        self[keyPath: property] = value
+        return self
+    }
+}

--- a/BentoTests/LegacyStyleSheetTests.swift
+++ b/BentoTests/LegacyStyleSheetTests.swift
@@ -1,0 +1,184 @@
+@testable import Bento
+import UIKit
+import XCTest
+
+class StyleSheetTests: XCTestCase {
+    func test_view_style_sheet() {
+        let view = UIView()
+        let styleSheet = ViewStyleSheet()
+        testStyleSheet(styleSheet, in: view, exemptions: [
+            "cornerRadius",
+            "masksToBounds",
+            "borderColor",
+            "borderWidth",
+            "shadowColor",
+            "shadowRadius",
+            "shadowOffset",
+            "shadowOpacity"
+        ])
+    }
+
+    func test_label_style_sheet() {
+        let label = UILabel()
+        let styleSheet = LabelStyleSheet(font: .boldSystemFont(ofSize: 11.0))
+        testStyleSheet(styleSheet, in: label, exemptions: [
+            "cornerRadius",
+            "masksToBounds",
+            "borderColor",
+            "borderWidth",
+            "shadowColor",
+            "shadowRadius",
+            "shadowOffset",
+            "shadowOpacity"
+        ])
+    }
+
+    func test_button_style_sheet() {
+        let button = UIButton()
+        let styleSheet = ButtonStyleSheet()
+        testStyleSheet(
+            styleSheet,
+            in: button,
+            exemptions: [
+                "textFont",
+                "masksToBounds",
+                "cornerRadius",
+                "titleColors",
+                "images",
+                "backgroundImages",
+                "numberOfLines",
+                "borderColor",
+                "borderWidth",
+                "textAlignment",
+                "lineBreakMode",
+                "shadowColor",
+                "shadowRadius",
+                "shadowOffset",
+                "shadowOpacity"
+            ]
+        )
+    }
+
+    func test_imageview_style_sheet() {
+        let imageView = UIImageView()
+        let styleSheet = ImageViewStyleSheet(contentMode: .scaleAspectFill)
+        testStyleSheet(styleSheet, in: imageView, exemptions: [
+            "cornerRadius",
+            "masksToBounds",
+            "size",
+            "borderColor",
+            "borderWidth",
+            "shadowColor",
+            "shadowRadius",
+            "shadowOffset",
+            "shadowOpacity"
+        ])
+    }
+
+    func test_stackview_style_sheet() {
+        let stackView = UIStackView()
+        let styleSheet = StackViewStyleSheet(axis: .vertical, spacing: 8, distribution: .fill, alignment: .fill)
+        testStyleSheet(styleSheet, in: stackView, exemptions: [
+            "cornerRadius",
+            "masksToBounds",
+            "borderColor",
+            "borderWidth",
+            "shadowColor",
+            "shadowRadius",
+            "shadowOffset",
+            "shadowOpacity"
+        ])
+    }
+
+    func test_test_field_styleSheet() {
+        let textField = TextField(frame: .zero)
+        let styleSheet = TextFieldStylesheet()
+
+        testStyleSheet(styleSheet, in: textField, exemptions: [
+            "cornerRadius",
+            "masksToBounds",
+            "borderColor",
+            "borderWidth",
+            "isSecureTextEntry",
+            "clearButtonMode",
+            "shadowColor",
+            "shadowRadius",
+            "shadowOffset",
+            "shadowOpacity"
+        ])
+        XCTAssertTrue(textField.isClearButtonModeCalled)
+        XCTAssertTrue(textField.isSecureTextEntryCalled)
+        XCTAssertTrue(textField.isBorderStyleCalled)
+    }
+
+    func testStyleSheet<S: StyleSheetProtocol, Element>(
+        _ styleSheet: S,
+        in element: Element,
+        exemptions: Set<String> = []
+    ) where S.Element == Element, Element: NSObject {
+        let observer = PropertyObserver()
+
+        let properties = Set(extract(propertiesFrom: Mirror(reflecting: styleSheet)))
+
+        properties.forEach { property in
+            element.addObserver(observer, forKeyPath: property, options: .new, context: nil)
+        }
+
+        styleSheet.apply(to: element)
+
+        let observedKeys = Set(observer.changes.map { $0.key })
+
+        let symmetricDifference = observedKeys
+            .symmetricDifference(properties)
+            .subtracting(exemptions)
+
+        XCTAssert(
+            symmetricDifference.isEmpty,
+            "\(type(of: styleSheet)) didn't use all the properties to configure \(type(of: element)) - properties missing: \(symmetricDifference)"
+        )
+    }
+}
+
+private func extract(propertiesFrom mirror: Mirror?) -> [String] {
+    guard let mirror = mirror else { return [] }
+    return mirror.children.compactMap { $0.label } + extract(propertiesFrom: mirror.superclassMirror)
+}
+
+private final class PropertyObserver: NSObject {
+    public var changes: [String: Any] = [:]
+
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        guard
+            let keyPath = keyPath,
+            let value = change?[.newKey]
+        else { fatalError() }
+
+        changes[keyPath] = value
+    }
+}
+
+final class TextField: UITextField {
+    var isSecureTextEntryCalled = false
+
+    override var isSecureTextEntry: Bool {
+        didSet {
+            isSecureTextEntryCalled = true
+        }
+    }
+
+    var isBorderStyleCalled = false
+
+    override var borderStyle: UITextField.BorderStyle {
+        didSet {
+            isBorderStyleCalled = true
+        }
+    }
+
+    var isClearButtonModeCalled = false
+
+    override var clearButtonMode: UITextField.ViewMode {
+        didSet {
+            isClearButtonModeCalled = true
+        }
+    }
+}

--- a/BentoTests/LegacyStyleSheetTests.swift
+++ b/BentoTests/LegacyStyleSheetTests.swift
@@ -2,7 +2,7 @@
 import UIKit
 import XCTest
 
-class StyleSheetTests: XCTestCase {
+class LegacyStyleSheetTests: XCTestCase {
     func test_view_style_sheet() {
         let view = UIView()
         let styleSheet = ViewStyleSheet()


### PR DESCRIPTION
Playbook Proposal: https://github.com/Babylonpartners/ios-playbook/pull/35

Credit: The Winter FP workshop & @dmcrodrigues, @ilyapuchka and @stephencelis.

## Problem Statement
The current inheritance based StyleSheet approach is unideal in three areas:

1. Ease of Use: Requiring upfront declarations of all styleable properties.

    We would have to constantly match UIKit changes. Custom views would require manual implementation.

2. Mental Model: Awkwardness when being applied to views that are opened for extension.

    When one defines a non generic `ExtensibleViewStyleSheet` for an `ExtensibleView`, the `StyleSheetProtocol.Element` associated type is immediately satisfied with the concrete view type. This means in a generic environment bound to `StyleSheetProtocol`, only `apply(to _: ExtensibleView)` would be recognised since `Element == ExtensibleView` per the conformance. In other words, all stylesheet subclasses must override this base class typed method & are required to downcast at runtime to access stuff defined in the subclass.

    On the other hand, when one defines a generic `ExtensibleViewStyleSheet<T: ExtensibleView>` stylesheet, it does address the said issue by satisfying `StyleSheetProtocol.Element` with a generic parameter. However, it leads to awkward and verbose spellings at use sites in general, e.g. `ExtensibleViewStyleSheet<ExtensibleView>`.

3. Correctness: Unintended Sharing

    Stylesheets are currently classes so as to be able to take advantage of inheritance, and this makes them prone to unintended sharing. With Swift offering first-class value type, this might amplify its possibility due to common perception of configurations being modelled as value types.

## Identified Requirements

1. The approach must be applicable to reusable views.

    When multiple style sheets with symmetrical differences are applied in a row in any order, the reused view would not end up in an indeterministic state.

1. The approach must be compatible with view subclassing.

1. The approach should address unintended sharing if possible.

## Proposed Solution

A new value type `StyleSheet<View>` shall be introduced, with the following features:

1. Copy on write & value semantics: Backed by CoW `Dictionary`.

2. Built around Key Paths introduced since Swift 4.

3. Inverses are produced for deterministic use on reusable views.

    Before applying a stylesheet, a snapshot of all affected key paths is taken, and is returned to the callee after the application. It is up to the callee whether to and when to apply the snapshot for change reversal.

    In the case of a reusable view/cell, the expectation is that the view would store the inverse/snapshot & apply it as part of the cleanup e.g. in `prepareForReuse()`.
    
    This eliminates the state indeterminism of closure-based styling approaches, while not requiring any default value to be declared upfront like how our `StyleSheet` framework currently does. 

4. Can be used for any view and any arbitrary subclass without type declaration.

5. `Equatable` conformance as a bonus, useful for #80 in determining layout equivalence.

### Potential Issues

Not all stying parameters are exposed as instance properties.

`UIButton` is the most apparent example. We could mitigate this by providing extensions with computed properties of `[UIControl.State: U]`.

    
## Impact on existing APIs
The value type `StyleSheet` is an additive change alone.

However, assuming we subsequently replace all existing BentoKit component style sheets, this shall be a massive source breaking change.

### Potential Migration Path
While script-based and staged migration is a viable solution, additional effort on top of snapshot testing might be required to verify that the removal of style sheet defaults does not lead to changes in visual appearance. 