### PR TITLE
Make `Button.View` properties public so they can be modified using composition

### DIFF
--- a/BentoKit/BentoKit/Components/Button.swift
+++ b/BentoKit/BentoKit/Components/Button.swift
@@ -59,7 +59,7 @@ extension Component.Button {
             }
         }()
 
-        fileprivate let button = Button(type: .system).with {
+        public let button = Button(type: .system).with {
             $0.setContentHuggingPriority(.required, for: .vertical)
         }
 
@@ -153,14 +153,14 @@ public extension Component.Button {
     }
 }
 
-private final class Button: UIButton {
+public class Button: UIButton {
     var autoRoundCorners: Bool = false {
         didSet {
             setNeedsLayout()
         }
     }
 
-    override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
         layer.cornerRadius = autoRoundCorners ? bounds.height * 0.5 : layer.cornerRadius
     }


### PR DESCRIPTION
## Description

Make `Button` component open so subclasses can modify rendering

## Why

For example in our case we want the title of a button to change every 5 seconds

In order to achieve this we can use object composition
```swift
private final class TickingButton: Renderable, HeightCustomizing {
        private let titles: SignalProducer<String, NoError>
        private let button: Component.Button

        init(
            button: Component.Button,
            titles: SignalProducer<String, NoError>) {
            self.button = button
            self.titles = titles
        }

        func height(forWidth width: CGFloat, inheritedMargins: UIEdgeInsets) -> CGFloat {
            return button.height(forWidth: width, inheritedMargins: inheritedMargins)
        }

        func estimatedHeight(forWidth width: CGFloat, inheritedMargins: UIEdgeInsets) -> CGFloat {
            return button.estimatedHeight(forWidth: width, inheritedMargins: inheritedMargins)
        }

        func render(in view: Component.Button.View) {
            button.render(in: view)
            view.disposable = view.button.reactive.title <~ titles
        }
    }
```

Why we do not want to re-render whole tree? Because it affects scroll position, so sometimes the content jumps when user scrolls and timer ticks.
