### PR TITLE
Update top view insets on safe area changes

### DIFF
--- a/BentoKit/BentoKit/Screen/BoxViewController.swift
+++ b/BentoKit/BentoKit/Screen/BoxViewController.swift
@@ -141,6 +141,7 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
     open override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
 
+        adjustTopTableViewInset()
         adjustBottomTableViewInset()
         updatePreferredContentHeight()
     }


### PR DESCRIPTION
Adjusting top insets is necessary for pinned to table to properly react on changes of safe area, i.e. when it is being used with the DrawerKit and does not take full screen (see 
https://github.com/Babylonpartners/babylon-ios/pull/6460)