### PR TITLE
[CE-141] Invalidate accessory view size when changing it's type

### DIFF
--- a/BentoKit/BentoKit/Views/Accessory.swift
+++ b/BentoKit/BentoKit/Views/Accessory.swift
@@ -72,6 +72,7 @@ public final class AccessoryView: InteractiveView {
         case .none:
             view = nil
         }
+        invalidateIntrinsicContentSize()
     }
 }
 


### PR DESCRIPTION
When the same component with `AccessoryView` is reused and different type of accessory is set, the `intrinsicContentSize` is not being recalculated.