### PR TITLE
Migrate to Swift 4.2

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 				TargetAttributes = {
 					5829D264200FB092001E020D = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 					58BA755B2016303B0050D5F1 = {
@@ -826,7 +827,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.babylonhealth.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -841,7 +842,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.babylonhealth.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -866,7 +867,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -892,7 +893,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.babylonhealth.FormsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Bento/Adapters/CollectionViewAdapter.swift
+++ b/Bento/Adapters/CollectionViewAdapter.swift
@@ -114,11 +114,15 @@ open class CollectionViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
 
     @objc(collectionView:canPerformAction:forItemAtIndexPath:withSender:)
     open func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath?, withSender sender: Any?) -> Bool {
-        guard let indexPath = indexPath,
-            let component = sections[indexPath.section].items[indexPath.row].component(as: MenuItemsResponding.self) else {
-            return false
+        guard let indexPath = indexPath else { return false }
+        return self.collectionView(collectionView, canPerformAction: action, forItemAt: indexPath, withSender: sender)
+    }
+    
+    open func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
+        guard let component = sections[indexPath.section].items[indexPath.row].component(as: MenuItemsResponding.self) else {
+                return false
         }
-
+        
         return component.responds(to: action)
     }
 

--- a/Bento/Adapters/TableViewAdapter.swift
+++ b/Bento/Adapters/TableViewAdapter.swift
@@ -65,11 +65,11 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
     }
 
     @objc open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return sections[section].supplements.keys.contains(.header) ? UITableViewAutomaticDimension : .leastNonzeroMagnitude
+        return sections[section].supplements.keys.contains(.header) ? UITableView.automaticDimension : .leastNonzeroMagnitude
     }
 
     @objc open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return sections[section].supplements.keys.contains(.footer) ? UITableViewAutomaticDimension : .leastNonzeroMagnitude
+        return sections[section].supplements.keys.contains(.footer) ? UITableView.automaticDimension : .leastNonzeroMagnitude
     }
 
     @objc(tableView:editActionsForRowAtIndexPath:)

--- a/Bento/Adapters/TableViewAnimation.swift
+++ b/Bento/Adapters/TableViewAnimation.swift
@@ -1,15 +1,15 @@
 import UIKit
 
 public struct TableViewAnimation {
-    let sectionInsertion: UITableViewRowAnimation
-    let sectionDeletion: UITableViewRowAnimation
-    let rowDeletion: UITableViewRowAnimation
-    let rowInsertion: UITableViewRowAnimation
+    let sectionInsertion: UITableView.RowAnimation
+    let sectionDeletion: UITableView.RowAnimation
+    let rowDeletion: UITableView.RowAnimation
+    let rowInsertion: UITableView.RowAnimation
 
-    public init(sectionInsertion: UITableViewRowAnimation = .fade,
-                sectionDeletion: UITableViewRowAnimation = .fade,
-                rowDeletion: UITableViewRowAnimation = .fade,
-                rowInsertion: UITableViewRowAnimation = .fade) {
+    public init(sectionInsertion: UITableView.RowAnimation = .fade,
+                sectionDeletion: UITableView.RowAnimation = .fade,
+                rowDeletion: UITableView.RowAnimation = .fade,
+                rowInsertion: UITableView.RowAnimation = .fade) {
         self.sectionInsertion = sectionInsertion
         self.sectionDeletion = sectionDeletion
         self.rowDeletion = rowDeletion

--- a/Bento/Bento/Supplement.swift
+++ b/Bento/Bento/Supplement.swift
@@ -8,9 +8,9 @@ extension Supplement {
     internal var elementKind: String {
         switch self {
         case .header:
-            return UICollectionElementKindSectionHeader
+            return UICollectionView.elementKindSectionHeader
         case .footer:
-            return UICollectionElementKindSectionFooter
+            return UICollectionView.elementKindSectionFooter
         case let .custom(kind):
             return kind
         }
@@ -18,9 +18,9 @@ extension Supplement {
 
     internal init(collectionViewSupplementaryKind kind: String) {
         switch kind {
-        case UICollectionElementKindSectionHeader:
+        case UICollectionView.elementKindSectionHeader:
             self = .header
-        case UICollectionElementKindSectionFooter:
+        case UICollectionView.elementKindSectionFooter:
             self = .footer
         default:
             self = .custom(kind)

--- a/Bento/Renderable/AnyRenderable.swift
+++ b/Bento/Renderable/AnyRenderable.swift
@@ -29,14 +29,14 @@ struct AnyRenderable: Renderable {
 
     func sizeBoundTo(width: CGFloat, inheritedMargins: UIEdgeInsets) -> CGSize {
         return rendered(inheritedMargins: inheritedMargins)
-            .systemLayoutSizeFitting(CGSize(width: width, height: UILayoutFittingCompressedSize.height),
+            .systemLayoutSizeFitting(CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
                                      withHorizontalFittingPriority: .required,
                                      verticalFittingPriority: .defaultLow)
     }
 
     func sizeBoundTo(height: CGFloat, inheritedMargins: UIEdgeInsets) -> CGSize {
         return rendered(inheritedMargins: inheritedMargins)
-            .systemLayoutSizeFitting(CGSize(width: UILayoutFittingCompressedSize.width, height: height),
+            .systemLayoutSizeFitting(CGSize(width: UIView.layoutFittingCompressedSize.width, height: height),
                                      withHorizontalFittingPriority: .defaultLow,
                                      verticalFittingPriority: .required)
     }

--- a/Bento/Views/TableViewContainerCell.swift
+++ b/Bento/Views/TableViewContainerCell.swift
@@ -9,7 +9,7 @@ final class TableViewContainerCell: UITableViewCell {
 
     var component: AnyRenderable?
 
-    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .none
         backgroundColor = .clear

--- a/Example/BookAppointmentViewController.swift
+++ b/Example/BookAppointmentViewController.swift
@@ -55,8 +55,8 @@ final class BookAppointmentViewController: UIViewController {
     private func setupTableView() {
         tableView.estimatedSectionFooterHeight = 18
         tableView.estimatedSectionHeaderHeight = 18
-        tableView.sectionHeaderHeight = UITableViewAutomaticDimension
-        tableView.sectionFooterHeight = UITableViewAutomaticDimension
+        tableView.sectionHeaderHeight = UITableView.automaticDimension
+        tableView.sectionFooterHeight = UITableView.automaticDimension
 
         let adapter = CustomTableViewAdapter<BookAppointmentViewModel.Renderer.SectionId, BookAppointmentViewModel.Renderer.RowId>(with: tableView)
         tableView.prepareForBoxRendering(with: adapter)

--- a/Example/PersonalDetailsViewController.swift
+++ b/Example/PersonalDetailsViewController.swift
@@ -32,8 +32,8 @@ final class PersonalDetailsViewController: UIViewController {
     private func setupTableView() {
         tableView.estimatedSectionFooterHeight = 18
         tableView.estimatedSectionHeaderHeight = 18
-        tableView.sectionHeaderHeight = UITableViewAutomaticDimension
-        tableView.sectionFooterHeight = UITableViewAutomaticDimension
+        tableView.sectionHeaderHeight = UITableView.automaticDimension
+        tableView.sectionFooterHeight = UITableView.automaticDimension
         tableView.keyboardDismissMode = .interactive
     }
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -65,8 +65,8 @@ class ViewController: UIViewController {
     private func setupTableView() {
         tableView.estimatedSectionFooterHeight = 18
         tableView.estimatedSectionHeaderHeight = 18
-        tableView.sectionHeaderHeight = UITableViewAutomaticDimension
-        tableView.sectionFooterHeight = UITableViewAutomaticDimension
+        tableView.sectionHeaderHeight = UITableView.automaticDimension
+        tableView.sectionFooterHeight = UITableView.automaticDimension
     }
 
     private func renderFirstSection() -> Section<SectionId, RowId> {


### PR DESCRIPTION
I was toying around with Bento in Xcode 10.1 and noticed that Bento's still using Swift 4.0 so I decided to open this PR. It was pretty straightforward but:

1. I didn't update the dependencies (not sure if you want this or not right now), so there are still warnings popping up regarding them.

2. there was a `different optionality` warning in the CollectionViewAdapter due to the fact that the method ```open func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath?, withSender sender: Any?) -> Bool``` is using an optional IndexPath but the actual UICollectionViewDelegate wants it to be non-optional. 

Guessing that's like that because of Objective-C interop? Ideally, the indexPath shouldn't really be an optional.
