### PR TITLE
Screen Lifecycle.

### DIFF
--- a/BentoKit/BentoKit.xcodeproj/project.pbxproj
+++ b/BentoKit/BentoKit.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		58801195216271DB0084EE07 /* TitledDescriptionLegacySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5880118A216271DA0084EE07 /* TitledDescriptionLegacySnapshotTests.swift */; };
 		5880119E216272C30084EE07 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5880119D216272C30084EE07 /* Device.swift */; };
 		588011A02162740C0084EE07 /* FBSnapshotTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5880119F2162740C0084EE07 /* FBSnapshotTestCaseExtensions.swift */; };
+		6548A8EB21EC5D8100F35AF4 /* ScreenLifecycleEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6548A8EA21EC5D8100F35AF4 /* ScreenLifecycleEvent.swift */; };
 		65E4D8B3225D006300CA7CB3 /* BoxSizeCachingTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4D8B2225D006300CA7CB3 /* BoxSizeCachingTableView.swift */; };
 		74CECF3722675C2E00EC6927 /* Bool+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74CECF3222675C2D00EC6927 /* Bool+Assertions.swift */; };
 		74CECF3822675C2E00EC6927 /* NSLayoutConstraintExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74CECF3322675C2E00EC6927 /* NSLayoutConstraintExtensions.swift */; };
@@ -69,6 +70,7 @@
 		588011A121627D520084EE07 /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		588011A321627D570084EE07 /* ReactiveSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReactiveSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		639430F94D2A3AB0B5FBBFF0 /* Pods_BentoKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BentoKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6548A8EA21EC5D8100F35AF4 /* ScreenLifecycleEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenLifecycleEvent.swift; sourceTree = "<group>"; };
 		65E4D8B2225D006300CA7CB3 /* BoxSizeCachingTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoxSizeCachingTableView.swift; sourceTree = "<group>"; };
 		7468960822675DDD00363024 /* BentoKit.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = BentoKit.podspec; path = ../BentoKit.podspec; sourceTree = "<group>"; };
 		74CECF3222675C2D00EC6927 /* Bool+Assertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Bool+Assertions.swift"; path = "../../Common/Bool+Assertions.swift"; sourceTree = "<group>"; };
@@ -278,6 +280,7 @@
 				A6EC2DAB218B28AA002B128F /* BoxViewModel.swift */,
 				A6EC2DAC218B28AA002B128F /* BoxViewController.swift */,
 				A6EC2DAD218B28AA002B128F /* BoxRenderer.swift */,
+				6548A8EA21EC5D8100F35AF4 /* ScreenLifecycleEvent.swift */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -418,6 +421,7 @@
 				A6EC2DB0218B28AA002B128F /* BoxViewModel.swift in Sources */,
 				74CECF3722675C2E00EC6927 /* Bool+Assertions.swift in Sources */,
 				A6EC2DB2218B28AA002B128F /* BoxRenderer.swift in Sources */,
+				6548A8EB21EC5D8100F35AF4 /* ScreenLifecycleEvent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BentoKit/BentoKit/Screen/BoxViewController.swift
+++ b/BentoKit/BentoKit/Screen/BoxViewController.swift
@@ -42,10 +42,6 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
         }
     }
 
-    private var lifetimeObserver: ScreenLifecycleObserving? {
-        return viewModel as? ScreenLifecycleObserving
-    }
-
     private var isPresentedInitially: Bool {
         return (parent != nil && isMovingToParent)
             || (presentingViewController != nil && isBeingPresented)
@@ -83,7 +79,7 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
         setupTableViews()
         setupLayout()
 
-        lifetimeObserver?.send(.didLoad)
+        viewModel.send(.didLoad)
     }
 
     open override func viewWillAppear(_ animated: Bool) {
@@ -97,14 +93,14 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
             bindViewModel()
         }
 
-        lifetimeObserver?.send(.willAppear(isPresentedInitially: isPresentedInitially))
+        viewModel.send(.willAppear(isPresentedInitially: isPresentedInitially))
     }
 
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         hasViewAppeared.value = true
 
-        lifetimeObserver?.send(.didAppear(isPresentedInitially: isPresentedInitially))
+        viewModel.send(.didAppear(isPresentedInitially: isPresentedInitially))
 
         keyboardChangeDisposable = NotificationCenter.default.reactive
             .keyboard(.willChangeFrame)
@@ -140,7 +136,7 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
         super.viewWillDisappear(animated)
         hasViewAppeared.value = false
 
-        lifetimeObserver?.send(.willDisappear(isRemovedPermanently: isRemovedPermanently))
+        viewModel.send(.willDisappear(isRemovedPermanently: isRemovedPermanently))
 
     }
 
@@ -148,7 +144,7 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
         super.viewDidDisappear(animated)
         keyboardChangeDisposable?.dispose()
 
-        lifetimeObserver?.send(.didDisappear(isRemovedPermanently: isRemovedPermanently))
+        viewModel.send(.didDisappear(isRemovedPermanently: isRemovedPermanently))
     }
 
     open override func viewDidLayoutSubviews() {

--- a/BentoKit/BentoKit/Screen/BoxViewModel.swift
+++ b/BentoKit/BentoKit/Screen/BoxViewModel.swift
@@ -8,4 +8,9 @@ public protocol BoxViewModel: AnyObject {
     var state: Property<State>  { get }
 
     func send(action: Action)
+    func send(_ event: ScreenLifecycleEvent)
+}
+
+extension BoxViewModel {
+    public func send(_ event: ScreenLifecycleEvent) {}
 }

--- a/BentoKit/BentoKit/Screen/ScreenLifecycleEvent.swift
+++ b/BentoKit/BentoKit/Screen/ScreenLifecycleEvent.swift
@@ -1,0 +1,38 @@
+public protocol ScreenLifecycleObserving {
+    func send(_ event: ScreenLifecycleEvent)
+}
+
+public enum ScreenLifecycleEvent: Equatable {
+    /// The screen has been loaded, but is not yet part of a view hierarchy.
+    case didLoad
+
+    /// The screen is about to appear because its parent intends to insert it into its view hierarchy.
+    ///
+    /// - isPresentedInitially: Whether this is the first time the parent has presented this screen. This would be
+    ///                         `false` when, for example, a screen in a navigation flow is about to appear again
+    ///                         because the user pops back to it.
+    case willAppear(isPresentedInitially: Bool)
+
+    /// The screen has been added to the view hierarchy. This need not happen at the exact moment the addition had
+    /// happened — it could be triggered at the end of an animated transition, for example.
+    ///
+    /// - isPresentedInitially: Whether this is the first time the parent has presented this screen. This would be
+    ///                         `false` when, for example, a screen in a navigation flow has appeared again because the
+    ///                         user pops back to it.
+    case didAppear(isPresentedInitially: Bool)
+
+    /// The screen is about to disappear because its parent intends to remove it from its view hierarchy.
+    ///
+    /// - isRemovedPermanently: Whether the parent intends to remove this screen permanently from its arrangement. This
+    ///                         would be `false` when, for example, a screen in a navigation flow is about to be hidden
+    ///                         because another screen is pushed.
+    case willDisappear(isRemovedPermanently: Bool)
+
+    /// The screen has been removed from a view hierarchy. This need not happen at the exact moment the removal had
+    /// happened — it could be triggered at the end of an animated transition, for example.
+    ///
+    /// - isRemovedPermanently: Whether the parent has removed this screen permanently from its arrangement. This
+    ///                         would be `false` when, for example, a screen in a navigation flow has been hidden
+    ///                         because another screen is pushed.
+    case didDisappear(isRemovedPermanently: Bool)
+}

--- a/BentoKit/BentoKit/Screen/ScreenLifecycleEvent.swift
+++ b/BentoKit/BentoKit/Screen/ScreenLifecycleEvent.swift
@@ -1,7 +1,3 @@
-public protocol ScreenLifecycleObserving {
-    func send(_ event: ScreenLifecycleEvent)
-}
-
 public enum ScreenLifecycleEvent: Equatable {
     /// The screen has been loaded, but is not yet part of a view hierarchy.
     case didLoad


### PR DESCRIPTION
Introduce a mechanism for `BoxViewModel` to be notified of the screen lifecycle.

`BoxViewModel` conforming to `ScreenLifecycleAware` would be invoked with `send(_: ScreenLifecycleEvent)` whenever the status of the screen changes. It is up to the view model whether or not it responds to the lifecycle event with a state transition.

`ScreenLifecycleEvent` exposes stages of presentation and dismissal, and special attributes for knowing whether the screen is initially presented or is to be removed indefinitely.