### PR TITLE
Hide image and label. Add accessibility ids.

### DIFF
--- a/BentoKit/BentoKit/Views/ImageOrLabelView.swift
+++ b/BentoKit/BentoKit/Views/ImageOrLabelView.swift
@@ -6,6 +6,8 @@ import ReactiveCocoa
 public typealias ImageOrLabel = ImageOrLabelView.Content
 
 open class ImageOrLabelView: UIView {
+    public static let labelAccessibilityId = "BentoKit.ImageOrLabelView.image"
+    public static let imageAccessibilityId = "BentoKit.ImageOrLabelView.label"
 
     public static func labelStyleSheet(font: UIFont) -> LabelStyleSheet {
         return LabelStyleSheet(font: font,
@@ -115,6 +117,8 @@ private extension ImageOrLabelView {
         backgroundColor = .clear
         label.add(to: self).pinEdges(to: self)
         imageView.add(to: self).pinEdges(to: layoutMarginsGuide)
+        imageView.accessibilityIdentifier = ImageOrLabelView.labelAccessibilityId
+        label.accessibilityIdentifier = ImageOrLabelView.imageAccessibilityId
     }
 
     func setImage(_ image: UIImage?) {
@@ -126,12 +130,18 @@ private extension ImageOrLabelView {
         switch content {
         case let .image(image):
             label.text = nil
+            label.isHidden = true
+            imageView.isHidden = false
             setImage(image)
         case let .text(text):
             label.text = text
+            label.isHidden = false
+            imageView.isHidden = true
             setImage(nil)
         case .none:
             label.text = nil
+            label.isHidden = true
+            imageView.isHidden = true
             setImage(nil)
         }
         invalidateIntrinsicContentSize()


### PR DESCRIPTION
# Why 

After I refactored one of our screens from Forms to Bento. I've noticed some of the tests where failing.

# How

1. Add accessibility IDs to the ImageOrLabel view
2. Also I've added hide and show logic for the `label` and `imageView` based on the `content`.

# Note 

This may seem like quick fix, but I guess we need to have an accessibility id for this view anyway ¯\_(ツ)_/¯

