### PR TITLE
Update Podspec Swift version to 4.2

### DIFF
--- a/Bento.podspec
+++ b/Bento.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/Babylonpartners/Bento.git", :tag => "#{s.version}" }
   s.source_files  = 'Bento/*.swift', 'Bento/**/*.swift'
 
-  s.swift_version = "4.1"
+  s.swift_version = "4.2"
   s.dependency "FlexibleDiff", "= 0.0.5"
 end


### PR DESCRIPTION
Bento's podspec in this repository is still pointing to Swift 4.1. 

As such, if I want to use the latest version of Bento after running `pod install` I have to manually alter the Swift version in its respective target from 4.1 to 4.2.