### PR TITLE
Allow customizing Button type

### DIFF
--- a/BentoKit/BentoKit/Components/Button.swift
+++ b/BentoKit/BentoKit/Components/Button.swift
@@ -65,6 +65,8 @@ extension Component.Button {
         private var huggingConstraints: [NSLayoutConstraint] = []
         private var strictConstraints: [NSLayoutConstraint] = []
 
+        fileprivate var interactionBehavior: InteractionBehavior = .becomeFirstResponder
+
         fileprivate var buttonType: UIButton.ButtonType = .system {
             didSet {
                 guard oldValue != buttonType else { return }

--- a/BentoKit/BentoKit/Components/Button.swift
+++ b/BentoKit/BentoKit/Components/Button.swift
@@ -7,6 +7,7 @@ extension Component {
 
         public let configurator: (View) -> Void
         public let styleSheet: StyleSheet
+        public let type: UIButton.ButtonType
 
         private let heightComputer: (CGFloat, UIEdgeInsets) -> CGFloat
 
@@ -15,8 +16,10 @@ extension Component {
             isEnabled: Bool = true,
             isLoading: Bool = false,
             didTap: (() -> Void)? = nil,
+            type: UIButton.ButtonType = .system,
             styleSheet: StyleSheet
         ) {
+            self.type = type
             self.configurator = { view in
                 view.isLoading = isLoading
                 view.button.isEnabled = isEnabled
@@ -39,6 +42,10 @@ extension Component {
             self.styleSheet = styleSheet
         }
 
+        public func generate() -> View {
+            return View(type: type)
+        }
+
         public func height(forWidth width: CGFloat, inheritedMargins: UIEdgeInsets) -> CGFloat {
             return heightComputer(width, inheritedMargins)
         }
@@ -59,9 +66,7 @@ extension Component.Button {
             }
         }()
 
-        public let button = Button(type: .system).with {
-            $0.setContentHuggingPriority(.required, for: .vertical)
-        }
+        public let button: Button
 
         private lazy var huggingConstraints: [NSLayoutConstraint] = [
             button.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor)
@@ -97,7 +102,21 @@ extension Component.Button {
         public var didTap: (() -> Void)?
 
         public override init(frame: CGRect) {
+            button = Button(type: .system)
             super.init(frame: frame)
+
+            postInit()
+        }
+
+        public init(type: UIButton.ButtonType) {
+            button = Button(type: type)
+            super.init(frame: .zero)
+
+            postInit()
+        }
+
+        private func postInit() {
+            button.setContentHuggingPriority(.required, for: .vertical)
             button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
             setupLayout()
         }
@@ -130,7 +149,7 @@ extension Component.Button {
 }
 
 public extension Component.Button {
-    public final class StyleSheet: BaseViewStyleSheet<View> {
+    public final class StyleSheet: InteractiveViewStyleSheet<View> {
         public let button: ButtonStyleSheet
         public let activityIndicator: ActivityIndicatorStyleSheet
         public var hugsContent: Bool

--- a/BentoKit/BentoKit/Components/Button.swift
+++ b/BentoKit/BentoKit/Components/Button.swift
@@ -136,10 +136,8 @@ extension Component.Button {
                     .withPriority(.defaultHigh)
             ]
 
-            if hugsContent {
-                huggingConstraints.forEach { $0.isActive = hugsContent }
-                strictConstraints.forEach { $0.isActive = hugsContent == false }
-            }
+            huggingConstraints.forEach { $0.isActive = hugsContent }
+            strictConstraints.forEach { $0.isActive = hugsContent == false }
 
             activityIndicator
                 .add(to: self)

--- a/BentoKit/BentoKit/Components/Button.swift
+++ b/BentoKit/BentoKit/Components/Button.swift
@@ -60,63 +60,18 @@ extension Component.Button {
         }()
 
         public var button = Button(type: .system)
+        private var huggingConstraints: [NSLayoutConstraint] = []
+        private var strictConstraints: [NSLayoutConstraint] = []
 
         fileprivate var buttonType: UIButton.ButtonType = .system {
             didSet {
                 guard oldValue != buttonType else { return }
 
-                activityIndicator.removeFromSuperview()
-                button.removeFromSuperview()
                 button = Button(type: buttonType)
-
-                _huggingConstraints = []
-                _strictConstraints = []
-
-                button.setContentHuggingPriority(.required, for: .vertical)
                 button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
+
                 setupLayout()
-
-                if hugsContent {
-                    huggingConstraints.forEach { $0.isActive = hugsContent }
-                    strictConstraints.forEach { $0.isActive = hugsContent == false }
-                }
-
-                if isLoading {
-                    activityIndicator.startAnimating()
-                }
             }
-        }
-
-        private var _huggingConstraints: [NSLayoutConstraint] = []
-        private var huggingConstraints: [NSLayoutConstraint] {
-            guard _huggingConstraints.isEmpty else {
-                return _huggingConstraints
-            }
-
-            _huggingConstraints = [
-                button.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor)
-                    .withPriority(.defaultHigh),
-                layoutMarginsGuide.trailingAnchor.constraint(greaterThanOrEqualTo: button.trailingAnchor)
-                    .withPriority(.defaultHigh)
-            ]
-
-            return _huggingConstraints
-        }
-
-        private var _strictConstraints: [NSLayoutConstraint] = []
-        private var strictConstraints: [NSLayoutConstraint] {
-            guard _strictConstraints.isEmpty else {
-                return _strictConstraints
-            }
-
-            _strictConstraints = [
-                button.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor)
-                    .withPriority(.defaultHigh),
-                layoutMarginsGuide.trailingAnchor.constraint(equalTo: button.trailingAnchor)
-                    .withPriority(.defaultHigh)
-            ]
-
-            return _strictConstraints
         }
 
         fileprivate var hugsContent: Bool = false {
@@ -141,7 +96,6 @@ extension Component.Button {
         public override init(frame: CGRect) {
             super.init(frame: frame)
 
-            button.setContentHuggingPriority(.required, for: .vertical)
             button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
             setupLayout()
         }
@@ -152,18 +106,44 @@ extension Component.Button {
         }
 
         private func setupLayout() {
+            activityIndicator.removeFromSuperview()
+            button.removeFromSuperview()
+
             button
                 .add(to: self)
                 .pinTop(to: layoutMarginsGuide)
                 .pinBottom(to: layoutMarginsGuide)
 
+
             button.centerXAnchor.constraint(equalTo: layoutMarginsGuide.centerXAnchor)
                 .activated()
-            strictConstraints.forEach { $0.isActive = true }
+
+            button.setContentHuggingPriority(.required, for: .vertical)
+            huggingConstraints = [
+                button.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor)
+                    .withPriority(.defaultHigh),
+                layoutMarginsGuide.trailingAnchor.constraint(greaterThanOrEqualTo: button.trailingAnchor)
+                    .withPriority(.defaultHigh)
+            ]
+            strictConstraints = [
+                button.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor)
+                    .withPriority(.defaultHigh),
+                layoutMarginsGuide.trailingAnchor.constraint(equalTo: button.trailingAnchor)
+                    .withPriority(.defaultHigh)
+            ]
+
+            if hugsContent {
+                huggingConstraints.forEach { $0.isActive = hugsContent }
+                strictConstraints.forEach { $0.isActive = hugsContent == false }
+            }
 
             activityIndicator
                 .add(to: self)
                 .pinCenter(to: button)
+
+            if isLoading {
+                activityIndicator.startAnimating()
+            }
         }
 
         @objc private func buttonPressed() {

--- a/BentoKit/BentoKitTests/SnapshotTests/Components/ButtonComponentSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/ButtonComponentSnapshotTests.swift
@@ -72,4 +72,19 @@ final class ButtonComponentSnapshotTests: SnapshotTestCase {
         )
         verifyComponentForAllSizes(component: component)
     }
+
+    func test_custom_hugs_content() {
+        UIView.setAnimationsEnabled(false)
+        let styleSheet = self.styleSheet
+            .compose(\.backgroundColor, .cyan)
+            .compose(\.hugsContent, true)
+            .compose(\.buttonType, .custom)
+
+        let component = Component.Button(
+            title: "Play",
+            isLoading: false,
+            styleSheet: styleSheet
+        )
+        verifyComponentForAllSizes(component: component)
+    }
 }

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_custom_hugs_content_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_custom_hugs_content_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb1a6cb3d4bd8ee4c43d30f6964a07aa8b794ffd699d7d82a8ab4e370d622382
+size 24717

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_custom_hugs_content_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_custom_hugs_content_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab9fa2dc800a70da2e6dbc5e58f922d510cd4a091f42151a0c156e851e86ad36
+size 28922

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_custom_hugs_content_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_custom_hugs_content_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f64c552a14e0828709a30031b634b6440fe2923ef94a9cadb0d3858a34679466
+size 29495


### PR DESCRIPTION
Also: Button should use InteractiveViewStyleSheet
Fixes #98 

Add a `type` to the Button component and allow this to be configured by the user. This allows using the `.custom` type, which is the only way to customize the button highlighted background colour without having a system fade applied. 

This was the actual cause of #98, not the incorrect style sheet type, but I fixed that also, just to be correct.