### PR TITLE
Fix a UICollectionView diff application issue.

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		61B64BB12086561B0092082C /* IntroRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B64BB02086561B0092082C /* IntroRenderer.swift */; };
 		61B64BB420873DA10092082C /* CollectionViewSectionDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B64BB320873DA10092082C /* CollectionViewSectionDiff.swift */; };
 		61B64BB6208745730092082C /* CollectionViewContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B64BB5208745730092082C /* CollectionViewContainerCell.swift */; };
+		651E75C0221005E300130866 /* UIKitContainerDiffApplicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E75BF221005E300130866 /* UIKitContainerDiffApplicationTests.swift */; };
 		65496FB8211C323F00511D8A /* TableViewContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587F0717201B355800ACD219 /* TableViewContainerCell.swift */; };
 		65496FB9211C323F00511D8A /* TableViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9509BC2762C8B4277B973D8 /* TableViewAdapter.swift */; };
 		65A69EDF218B8892005D90AC /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A69EDE218B8891005D90AC /* UICollectionViewExtensions.swift */; };
@@ -178,6 +179,7 @@
 		61B64BB02086561B0092082C /* IntroRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroRenderer.swift; sourceTree = "<group>"; };
 		61B64BB320873DA10092082C /* CollectionViewSectionDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewSectionDiff.swift; sourceTree = "<group>"; };
 		61B64BB5208745730092082C /* CollectionViewContainerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContainerCell.swift; sourceTree = "<group>"; };
+		651E75BF221005E300130866 /* UIKitContainerDiffApplicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitContainerDiffApplicationTests.swift; sourceTree = "<group>"; };
 		65A69EDE218B8891005D90AC /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensions.swift; sourceTree = "<group>"; };
 		65A69EE0218B8AB6005D90AC /* CustomCollectionViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionViewAdapter.swift; sourceTree = "<group>"; };
 		65BA922D20AF388F004AEF18 /* UITableViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableViewExtensions.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				58D27BA621B83B2700DC9600 /* DeletableTests.swift */,
 				5830C5E621F22DDC0029044B /* ComponentLifecycleAware.swift */,
 				58FC4421207CF29F00DA3614 /* Info.plist */,
+				651E75BF221005E300130866 /* UIKitContainerDiffApplicationTests.swift */,
 			);
 			path = BentoTests;
 			sourceTree = "<group>";
@@ -679,6 +682,7 @@
 				5830C5E721F22DDC0029044B /* ComponentLifecycleAware.swift in Sources */,
 				740921B620ACDDDA00B59F5C /* IfTests.swift in Sources */,
 				740921B820ACE5EC00B59F5C /* ConcatenationTests.swift in Sources */,
+				651E75C0221005E300130866 /* UIKitContainerDiffApplicationTests.swift in Sources */,
 				A67A873520B5D2D100BC2BAC /* RenderableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bento/Adapters/CollectionViewAdapter.swift
+++ b/Bento/Adapters/CollectionViewAdapter.swift
@@ -32,8 +32,7 @@ open class CollectionViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
         let diff = CollectionViewSectionDiff(oldSections: self.sections,
                                              newSections: sections,
                                              knownSupplements: knownSupplements)
-        self.sections = sections
-        diff.apply(to: collectionView, completion: completion)
+        diff.apply(to: collectionView, updateAdapter: { self.sections = sections }, completion: completion)
     }
 
     @objc(numberOfSectionsInCollectionView:)

--- a/Bento/Adapters/TableViewAdapter.swift
+++ b/Bento/Adapters/TableViewAdapter.swift
@@ -21,8 +21,7 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
         let diff = TableViewSectionDiff(oldSections: self.sections,
                                         newSections: sections,
                                         animation: animation)
-        self.sections = sections
-        diff.apply(to: tableView)
+        diff.apply(to: tableView, updateAdapter: { self.sections = sections })
     }
 
     func update(sections: [Section<SectionID, ItemID>]) {

--- a/BentoTests/UIKitContainerDiffApplicationTests.swift
+++ b/BentoTests/UIKitContainerDiffApplicationTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+import Nimble
+@testable import Bento
+
+class UIKitContainerDiffApplicationTests: XCTestCase {
+    func test_mixed_operations() {
+        let boxes: [Box<Int, Int>] = [
+            Box(sections: [
+                Section(id: 1, items: [
+                    Node(id: 100, component: EmptyRenderable()),
+                    Node(id: 101, component: EmptyRenderable()),
+                    Node(id: 102, component: EmptyRenderable()),
+                    Node(id: 103, component: EmptyRenderable())
+                    ]),
+                Section(id: 2, items: [
+                    Node(id: 200, component: EmptyRenderable()),
+                    Node(id: 201, component: EmptyRenderable())
+                    ]),
+                Section(id: 3, items: [
+                    Node(id: 300, component: EmptyRenderable()),
+                    Node(id: 301, component: EmptyRenderable())
+                    ])
+                ]),
+            Box(sections: [
+                // Inserted at 0
+                Section(id: 5, items: []),
+                // Moved from 2 to 1
+                Section(id: 3, items: [
+                    Node(id: 300, component: EmptyRenderable()),
+                    Node(id: 301, component: EmptyRenderable())
+                    ]),
+                // Moved from 1 to 2
+                Section(id: 1, items: [
+                    // Moved from 3 to 0
+                    Node(id: 103, component: EmptyRenderable()),
+                    // Deleted #101 at 1
+                    // Moved from 0 to 1
+                    Node(id: 100, component: EmptyRenderable()),
+                    Node(id: 102, component: EmptyRenderable())
+                    ]),
+                // Inserted @ 3
+                Section(id: 4, items: []),
+                // Moved from 2 to 4
+                Section(id: 2, items: [
+                    // Moved from 1 to 0
+                    Node(id: 201, component: EmptyRenderable()),
+                    // Inserted at 1
+                    Node(id: 202, component: EmptyRenderable()),
+                    // Moved from 0 to 2
+                    Node(id: 200, component: EmptyRenderable())
+                    ])
+                ])
+        ]
+
+        verify(UITableView.self, boxes)
+        verify(UICollectionView.self, boxes)
+    }
+
+    func test_insert_and_remove_the_same_element_CNSMR705() {
+        let boxes: [Box<Int, Int>] = [
+            Box(sections: [
+                Section(id: 1, items: [
+                    Node(id: 100, component: EmptyRenderable()),
+                    Node(id: 101, component: EmptyRenderable()),
+                    Node(id: 102, component: EmptyRenderable()),
+                    Node(id: 103, component: EmptyRenderable())
+                    ]),
+                Section(id: 2, items: [
+                    Node(id: 200, component: EmptyRenderable()),
+                    Node(id: 201, component: EmptyRenderable())
+                    ]),
+                ]),
+            Box(sections: [
+                Section(id: 1, items: [
+                    Node(id: 100, component: EmptyRenderable()),
+                    Node(id: 101, component: EmptyRenderable()),
+                    Node(id: 102, component: EmptyRenderable()),
+                    Node(id: 103, component: EmptyRenderable()),
+                    Node(id: 104, component: EmptyRenderable())
+                    ]),
+                Section(id: 2, items: [
+                    Node(id: 200, component: EmptyRenderable()),
+                    Node(id: 201, component: EmptyRenderable())
+                    ]),
+                ])
+        ]
+
+        verify(UITableView.self, boxes)
+        verify(UICollectionView.self, boxes)
+    }
+
+    private func verify<View: UIView & TestableContainer>(
+        _ type: View.Type,
+        _ boxes: [Box<Int, Int>],
+        count: Int = 10,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        let window = UIWindow()
+        window.frame.size = CGSize(width: 400, height: 400)
+        window.isHidden = false
+
+        let view = type.make()
+        window.addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinToEdges(of: window)
+
+        expect(
+            file,
+            line: line,
+            expression: { () -> Void in
+                for box in repeatElement(boxes, count: count).joined() {
+                    view.invalidateLayout()
+                    view._render(box)
+                    view.layoutIfNeeded()
+
+                    expect(view.numberOfSections) == box.sections.count
+
+                    for (offset, section) in box.sections.enumerated() {
+                        expect(view.numberOfItems(inSection: offset)) == section.items.count
+                    }
+                }
+            }
+        ).toNot(throwAssertion())
+    }
+}
+
+struct EmptyRenderable: Renderable {
+    func render(in view: UIView) {}
+}
+
+private protocol TestableContainer {
+    var numberOfSections: Int { get }
+    func numberOfItems(inSection section: Int) -> Int
+
+    static func make() -> UIView & TestableContainer
+    func _render(_ box: Box<Int, Int>)
+    func invalidateLayout()
+}
+
+extension UITableView: TestableContainer {
+    fileprivate static func make() -> UIView & TestableContainer {
+        return UITableView(frame: .zero, style: .plain)
+    }
+
+    fileprivate func _render(_ box: Box<Int, Int>) {
+        render(box)
+    }
+
+    fileprivate func invalidateLayout() {}
+
+    fileprivate func numberOfItems(inSection section: Int) -> Int {
+        return numberOfRows(inSection: section)
+    }
+}
+
+extension UICollectionView: TestableContainer {
+    fileprivate static func make() -> UIView & TestableContainer {
+        return UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    }
+
+    fileprivate func _render(_ box: Box<Int, Int>) {
+        render(box)
+    }
+
+    fileprivate func invalidateLayout() {
+        collectionViewLayout.invalidateLayout()
+    }
+}


### PR DESCRIPTION
**NOTE:** This is not a definitive fix for CNSMR-705, since I so far have no luck exactly reproducing it.

While attempting to reproduce CNSMR-705, a couple of issues are uncovered:

1. According to [the UIKit `performBatchUpdates` documentation](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates), we should update our data source within the update closure, unless we are sure that the layout is up-to-date when the method is invoked.

   Bento currently neither has assertion on freshness of layout, nor it updates its adapter at the appropriate time. This _might_ be an issue contributing to CNSMR-705.

   This PR makes Bento follow what the documentation says.

2. `CollectionViewSectionDiff` is not applying moves correctly. It uses the source section index to generate the destination index path, which would cause UICollectionView exception when, for example, both a section and its items are being moved at the same time.

Also added tests which assert `UITableView` and `UICollectionView` behaviours.