### PR TITLE
Make sure TitledDescription respects `textBlockWidthFraction` when calculating the height

### DIFF
--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -180,15 +180,24 @@ private extension Component.TitledDescription {
             } else {
                 accessorySize = CGSize(width: 24, height: 24)
             }
-            let availableWidthForLabelBlock = width
-                - max(styleSheet.layoutMargins.left, inheritedMargins.left)
-                - max(styleSheet.layoutMargins.right, inheritedMargins.right)
-                - (styleSheet.content.isLayoutMarginsRelativeArrangement
-                    ? styleSheet.content.layoutMargins.horizontalTotal
-                    : 0)
-                - imageWidthPlusSpacing(measuring: image, styleSheet: styleSheet)
-                - detailWidthPlusSpacing
-                - (accessory != .none ? accessorySize.width + xSpacing : 0)
+            let availableWidthForLabelBlock: CGFloat
+            if let textBlockWidthFraction = styleSheet.textBlockWidthFraction {
+                availableWidthForLabelBlock = (
+                    width
+                        - max(styleSheet.layoutMargins.left, inheritedMargins.left)
+                        - max(styleSheet.layoutMargins.right, inheritedMargins.right)
+                    ) * textBlockWidthFraction
+            } else {
+                availableWidthForLabelBlock = width
+                    - max(styleSheet.layoutMargins.left, inheritedMargins.left)
+                    - max(styleSheet.layoutMargins.right, inheritedMargins.right)
+                    - (styleSheet.content.isLayoutMarginsRelativeArrangement
+                        ? styleSheet.content.layoutMargins.horizontalTotal
+                        : 0)
+                    - imageWidthPlusSpacing(measuring: image, styleSheet: styleSheet)
+                    - detailWidthPlusSpacing
+                    - (accessory != .none ? accessorySize.width + xSpacing : 0)
+            }
 
             assert(availableWidthForLabelBlock > 0,
                    "availableWidthForLabelBlock (\(availableWidthForLabelBlock)) ≤ 0")

--- a/BentoKit/BentoKitTests/SnapshotTests/Components/TitledDescriptionSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/TitledDescriptionSnapshotTests.swift
@@ -261,4 +261,37 @@ final class TitledDescriptionSnapshotTests: SnapshotTestCase {
 
         verifyComponentForAllSizes(component: component)
     }
+
+    func test_long_detail_with_fraction() {
+        let component = Component.TitledDescription(
+            texts: [
+                .plain(Array(repeating: "Address", count: 10).joined(separator: " "))
+            ],
+            detail: "Megahight.com, 1 Lily Close 1 Lily Close",
+            accessory: .chevron,
+            styleSheet: Component.TitledDescription.StyleSheet(textBlockWidthFraction: 0.25)
+                .compose(\.detail.textColor, .gray)
+                .compose(\.detail.backgroundColor, .green)
+                .compose(\.textStyles[0].backgroundColor, .red)
+            )
+
+        verifyComponentForAllSizes(component: component)
+    }
+
+    func test_long_detail_with_fraction_and_fixed_number_of_lines() {
+        let component = Component.TitledDescription(
+            texts: [
+                .plain(Array(repeating: "Address", count: 10).joined(separator: " "))
+            ],
+            detail: "Megahight.com, 1 Lily Close 1 Lily Close",
+            accessory: .chevron,
+            styleSheet: Component.TitledDescription.StyleSheet(textBlockWidthFraction: 0.25)
+                .compose(\.detail.textColor, .gray)
+                .compose(\.detail.backgroundColor, .green)
+                .compose(\.textStyles[0].backgroundColor, .red)
+                .compose(\.textStyles[0].numberOfLines, 2)
+        )
+
+        verifyComponentForAllSizes(component: component)
+    }
 }

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_and_fixed_number_of_lines_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_and_fixed_number_of_lines_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4007195ed933ecaee15ae08231a858406005e673e0026496af3e2eb71ec31d9
+size 34380

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_and_fixed_number_of_lines_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_and_fixed_number_of_lines_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f24d26acf2cb1e10a538e56c545289e4af3c6d6eec3f3b631034cc4c32942fa0
+size 39568

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_and_fixed_number_of_lines_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_and_fixed_number_of_lines_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5c688c1ef86fffd0389d43fa857a222f3e6fc971e9597f9899c9a6d0d344fde
+size 39289

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09c0fbed7a102b2e120a1c5d8300463eccbb3ffa14384ef8f3f0beb83c729486
+size 50434

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d67890c560736a93804d205548ad95383f639d8d9e486e6abfd5e8c82e72962
+size 56011

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1908d6b7da1b269c2a538739525e46b8c2d819abd802329326b13f2491d4cdd7
+size 55345

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_with_fixed_number_of_lines_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_with_fixed_number_of_lines_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d89b063c88677e58bede8e7842543a6f8803b59b2efcbee3dd0fa5f9772bfee0
+size 34129

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_with_fixed_number_of_lines_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_with_fixed_number_of_lines_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:372ce9d152cad927073e750e404c6b71777ebcaab79d73a0a1b28e6a58c7e617
+size 39247

--- a/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_with_fixed_number_of_lines_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.TitledDescriptionSnapshotTests/test_long_detail_with_fraction_with_fixed_number_of_lines_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f48daefbc7446db657944935d142be97efc23cb0be33ac91a6fd2fcdf1665e86
+size 39008


### PR DESCRIPTION
## Why?

In case there is a long text in the `detail` field of the `TitledDescription` and `textBlockWidthFraction` is present we are getting assertion crash

![screenshot 2019-02-11 at 13 58 02](https://user-images.githubusercontent.com/4622322/52567913-5195d980-2e05-11e9-9424-f473470eff3a.png)

And in production we gonna have a broken UI

## How?

- Calculate width of the `texts` based on the `textBlockWidthFraction` value
- Added snapshot tests for this particular case

## How does it look?
| Before | After |
|---|---|
| <img width="375" alt="failed_test_long_detail_with_fraction_iphonex 2x" src="https://user-images.githubusercontent.com/4622322/52568033-9a4d9280-2e05-11e9-9601-77229c79de2d.png"> | <img width="375" alt="reference_test_long_detail_with_fraction_iphonex 2x" src="https://user-images.githubusercontent.com/4622322/52568045-a0437380-2e05-11e9-8acc-ecbeaf9953c3.png">
