### PR TITLE
Adds support for leading and trailing horizontal alignment.

### DIFF
--- a/BentoKit/BentoKitTests/SnapshotTests/Components/ButtonComponentSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/ButtonComponentSnapshotTests.swift
@@ -73,6 +73,34 @@ final class ButtonComponentSnapshotTests: SnapshotTestCase {
         verifyComponentForAllSizes(component: component)
     }
 
+    func test_leading_alignment() {
+        UIView.setAnimationsEnabled(false)
+        let styleSheet = self.styleSheet
+            .compose(\.backgroundColor, .cyan)
+            .compose(\.alignment, .leading)
+
+        let component = Component.Button(
+            title: "Play",
+            isLoading: false,
+            styleSheet: styleSheet
+        )
+        verifyComponentForAllSizes(component: component)
+    }
+
+    func test_trailing_alignment() {
+        UIView.setAnimationsEnabled(false)
+        let styleSheet = self.styleSheet
+            .compose(\.backgroundColor, .cyan)
+            .compose(\.alignment, .trailing)
+
+        let component = Component.Button(
+            title: "Play",
+            isLoading: false,
+            styleSheet: styleSheet
+        )
+        verifyComponentForAllSizes(component: component)
+    }
+
     func test_custom_hugs_content() {
         UIView.setAnimationsEnabled(false)
         let styleSheet = self.styleSheet

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_leading_alignment_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_leading_alignment_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2245d5b23ab0ccbee0fd9c2bd64d2a4bad44290685dce3f77ae33ae89aca8d6
+size 24552

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_leading_alignment_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_leading_alignment_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ada1762970a44a386712d52509ea1f0b53833bbf77ecc8378a54bd9defbb2e17
+size 28787

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_leading_alignment_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_leading_alignment_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:457ef00c38d26a4883573e6e3551693c332f782fc06320f4cfdc96fa77d9838a
+size 29328

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_trailing_alignment_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_trailing_alignment_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4b3b58a4a9d6747241c2fa3906f001a8a4f2204787ff7e94b32fd8753763488
+size 24683

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_trailing_alignment_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_trailing_alignment_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f6b9f5fb1f11f065d92d05f96e42a835516f9964beea2d29bdbc8212d0280da
+size 28888

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_trailing_alignment_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_trailing_alignment_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d0e327833b763741e0b1135e47843de77ee95b4c94edfb0a0136606f847bdab
+size 29457


### PR DESCRIPTION
This adds the `alignment` property to `Component.Button.StyleSheet` to allow having buttons aligned with the leading or trailing `layoutMargin`s of the component view.

Currently only center alignment is supported. The default continues to be `.center` and this makes the change backwards compatible with existing code.

Also fixes a bug so the height of a button which has only an image (and no text) is correct, when `enforcesMinimumHeight` is `false`.