### PR TITLE
Nested AnyRenderable should propagate out the correct `viewType`.

### DIFF
--- a/Bento/Renderable/AnyRenderable.swift
+++ b/Bento/Renderable/AnyRenderable.swift
@@ -70,7 +70,7 @@ class AnyRenderableBox<Base: Renderable>: AnyRenderableBoxBase where Base.View: 
     }
 
     override var viewType: Any.Type {
-        return Base.View.self
+        return (base as? AnyRenderable)?.viewType ?? Base.View.self
     }
 
     let base: Base

--- a/BentoTests/AnyRenderableTests.swift
+++ b/BentoTests/AnyRenderableTests.swift
@@ -22,6 +22,25 @@ class AnyRenderableTests: XCTestCase {
         renderable.render(in: testView)
         expect(testView.hasInvoked) == true
     }
+
+    func test_should_see_view_type_through_nested_wrapping() {
+        let component = TestRenderable(reuseIdentifier: "", generate: { TestView() }, render: { _ in })
+
+        func wrapping(component: TestRenderable, count: Int) -> AnyRenderable {
+            precondition(count >= 1)
+            return count > 1
+                ? AnyRenderable(wrapping(component: component, count: count - 1))
+                : AnyRenderable(component)
+        }
+
+        expect(wrapping(component: component, count: 1).viewType) === TestView.self
+        expect(wrapping(component: component, count: 2).viewType) === TestView.self
+        expect(wrapping(component: component, count: 3).viewType) === TestView.self
+        expect(wrapping(component: component, count: 4).viewType) === TestView.self
+        expect(wrapping(component: component, count: 5).viewType) === TestView.self
+        expect(wrapping(component: component, count: 6).viewType) === TestView.self
+        expect(wrapping(component: component, count: 7).viewType) === TestView.self
+    }
 }
 
 private class TestView: UIView {


### PR DESCRIPTION
Currently, if you wrap an `AnyRenderable` with another `AnyRenderable`, it does not give the expected view type (the original one).

This causes the component binding mechanism to treat components as being different in type, even if ultimately they are resolving to the same component view type.