### PR TITLE
Update the UIKit Integration Tests.

### DIFF
--- a/BentoTests/UIKitContainerDiffApplicationTests.swift
+++ b/BentoTests/UIKitContainerDiffApplicationTests.swift
@@ -164,6 +164,6 @@ extension UICollectionView: TestableContainer {
     }
 
     fileprivate func invalidateLayout() {
-        collectionViewLayout.invalidateLayout()
+        reloadData()
     }
 }


### PR DESCRIPTION
The exception trigger for #106 is actually `reloadData()`, not `collectionViewLayout.invalidateLayout()` alone. Update the test to reflect it.