### PR TITLE
Add as any renderable method to `Renderable`

### DIFF
--- a/Bento/Renderable/Renderable.swift
+++ b/Bento/Renderable/Renderable.swift
@@ -19,6 +19,10 @@ public extension Renderable where View: UIView {
     func generate() -> View {
         return View()
     }
+
+    public func asAnyRenderable() -> AnyRenderable {
+        return AnyRenderable(self)
+    }
 }
 
 public extension Renderable where View: UIView & NibLoadable {


### PR DESCRIPTION
### Why

We need this for the components library to erase the type of returning component