### PR TITLE
Reuse TextField Implementation

### DIFF
--- a/BentoKit/BentoKit.xcodeproj/project.pbxproj
+++ b/BentoKit/BentoKit.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		B5234D63216EB0060061AD8B /* ImageOrLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234D62216EB0060061AD8B /* ImageOrLabel.swift */; };
 		B5BD11C6219301D500DC6A51 /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BD11C5219301D500DC6A51 /* Search.swift */; };
 		B5BD11C821930A2400DC6A51 /* SearchSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BD11C721930A2400DC6A51 /* SearchSnapshotTests.swift */; };
+		F21326B2221EF0850017F944 /* FocusTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F21326B1221EF0850017F944 /* FocusTextField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -190,6 +191,7 @@
 		B5234D62216EB0060061AD8B /* ImageOrLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageOrLabel.swift; sourceTree = "<group>"; };
 		B5BD11C5219301D500DC6A51 /* Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
 		B5BD11C721930A2400DC6A51 /* SearchSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSnapshotTests.swift; sourceTree = "<group>"; };
+		F21326B1221EF0850017F944 /* FocusTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTextField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -339,6 +341,7 @@
 				580B6140215D343E00A69E87 /* InteractiveView.swift */,
 				585B4B1E215E721600C8304A /* BentoTableView.swift */,
 				7421E0272192D9B70014F631 /* Resources.swift */,
+				F21326B1221EF0850017F944 /* FocusTextField.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -635,6 +638,7 @@
 				580B614A215D353B00A69E87 /* InputNodes.swift in Sources */,
 				B5BD11C6219301D500DC6A51 /* Search.swift in Sources */,
 				65020C3022030CB000DC8F42 /* InteractionBehavior.swift in Sources */,
+				F21326B2221EF0850017F944 /* FocusTextField.swift in Sources */,
 				580B6134215D2F6800A69E87 /* TextInput.swift in Sources */,
 				A6EC2DB0218B28AA002B128F /* BoxViewModel.swift in Sources */,
 				580B611F215D2F6100A69E87 /* HeightCustomizing.swift in Sources */,

--- a/BentoKit/BentoKit/Components/TextInput.swift
+++ b/BentoKit/BentoKit/Components/TextInput.swift
@@ -15,8 +15,8 @@ extension Component {
             text: TextValue? = nil,
             keyboardType: UIKeyboardType = .default,
             isEnabled: Bool = true,
-            accessory: Accessory = .none,
-            textWillChange: Optional<(TextChange) -> Bool> = nil,
+            accessory: FocusTextField.Accessory = .none,
+            textWillChange: Optional<(FocusTextField.TextChange) -> Bool> = nil,
             textDidChange: Optional<(String?) -> Void> = nil,
             didTapAccessory: Optional<() -> Void> = nil,
             styleSheet: StyleSheet
@@ -24,35 +24,19 @@ extension Component {
             self.configurator = { view in
                 view.titleLabel.text = title
                 view.titleLabel.isHidden = title?.isEmpty ?? true
-                view.textField.placeholder = placeholder
-                view.textField.keyboardType = keyboardType
-                view.textField.isEnabled = isEnabled
-                text?.apply(to: view.textField)
-                view.accessoryView.accessory = accessory.toAccessoryViewAccessory
-                view.accessoryView.didTap = didTapAccessory
-                view.textWillChange = textWillChange
-                view.textDidChange = textDidChange
+                view.textField.textField.placeholder = placeholder
+                view.textField.textField.keyboardType = keyboardType
+                view.textField.textField.isEnabled = isEnabled
+                text?.apply(to: view.textField.textField)
+                view.textField.accessoryView.accessory = accessory.toAccessoryViewAccessory
+                view.textField.accessoryView.didTap = didTapAccessory
+                view.textField.textWillChange = textWillChange
+                view.textField.textDidChange = textDidChange
             }
 
             let isNotEmpty = text?.isEmpty ?? false
             self.focusEligibility = isNotEmpty ? .eligible(.populated) : .eligible(.empty)
             self.styleSheet = styleSheet
-        }
-    }
-}
-
-extension Component.TextInput {
-    public struct TextChange {
-        public let current: String?
-        public let change: String
-        public let range: NSRange
-
-        public var result: String {
-            guard let current = self.current,
-                  let range = Range(range, in: current)
-                else { return "" }
-
-            return current.replacingCharacters(in: range, with: change)
         }
     }
 }
@@ -73,8 +57,7 @@ extension Component.TextInput {
         }
 
         fileprivate let titleLabel = UILabel()
-        fileprivate let textField = UITextField()
-        fileprivate let accessoryView = AccessoryView()
+        fileprivate let textField = FocusTextField()
 
         fileprivate var titleStyle: TitleStyle = .fit {
             didSet {
@@ -83,7 +66,7 @@ extension Component.TextInput {
                     titleLabelWidthConstraint = nil
                 case let .fillProportionally(proportion):
                     titleLabelWidthConstraint = titleLabel.widthAnchor.constraint(
-                        equalTo: contentView.widthAnchor,
+                        equalTo: widthAnchor,
                         multiplier: proportion
                     )
                     .withPriority(.required)
@@ -91,17 +74,12 @@ extension Component.TextInput {
             }
         }
 
-        var textWillChange: Optional<(TextChange) -> Bool> = nil
-        var textDidChange: Optional<(String?) -> Void> = nil
-
         override init(frame: CGRect) {
             super.init(frame: frame)
             setupLayout()
         }
 
         private func setupLayout() {
-            preservesSuperviewLayoutMargins = true
-
             contentView
                 .add(to: self)
                 .pinEdges(to: layoutMarginsGuide)
@@ -113,68 +91,16 @@ extension Component.TextInput {
             textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
             stack(.horizontal, spacing: 16.0, distribution: .fill, alignment: .center)(
-                titleLabel, textField, accessoryView
+                titleLabel, textField
             )
             .add(to: contentView)
             .pinEdges(to: contentView.layoutMarginsGuide)
-
-            textField.addTarget(self, action: #selector(textDidChangeOn(_:)), for: UIControl.Event.editingChanged)
-            textField.delegate = self
         }
 
         @available(*, unavailable)
         public required init?(coder aDecoder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
-
-        @objc private func textDidChangeOn(_ textField: UITextField) {
-            self.textDidChange?(textField.text)
-        }
-
-        @objc public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-            return textWillChange?(
-                .init(current: textField.text, change: string, range: range)
-                ) ?? true
-        }
-
-        @objc public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-            withFocusCoordinator { coordinator in
-                if !coordinator.move(.backward) {
-                    textField.resignFirstResponder()
-                }
-            }
-
-            return false
-        }
-
-        @objc public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-            updateReturnKey()
-            textField.inputAccessoryView = FocusToolbar(view: self)
-            return true
-        }
-
-        public func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
-            textField.inputAccessoryView = nil
-        }
-
-        private func updateReturnKey() {
-            withFocusCoordinator { coordinator in
-                let usesNextKey = coordinator.canMove(.backward)
-                textField.returnKeyType = usesNextKey ? .next : .done
-            }
-        }
-    }
-}
-
-extension Component.TextInput.View: FocusableView {
-    public func focus() {
-        textField.becomeFirstResponder()
-    }
-
-    public func neighboringFocusEligibilityDidChange() {
-        updateReturnKey()
-        (textField.inputAccessoryView as? FocusToolbar)?.updateFocusEligibility(with: self)
-        textField.reloadInputViews()
     }
 }
 
@@ -182,7 +108,7 @@ extension Component.TextInput {
     public final class StyleSheet: BaseViewStyleSheet<View> {
         public var titleStyle: View.TitleStyle
         public let title: LabelStyleSheet
-        public let text: TextFieldStylesheet
+        public let text: FocusTextField.StyleSheet
         public let content: ViewStyleSheet<UIView>
 
         public init(
@@ -191,7 +117,7 @@ extension Component.TextInput {
                 font: UIFont.preferredFont(forTextStyle: .body),
                 textAlignment: .leading
             ),
-            text: TextFieldStylesheet = TextFieldStylesheet(),
+            text: FocusTextField.StyleSheet = FocusTextField.StyleSheet(),
             content: ViewStyleSheet<UIView> = ViewStyleSheet(layoutMargins: .zero)
         ) {
             self.titleStyle = titleStyle
@@ -206,23 +132,6 @@ extension Component.TextInput {
             title.apply(to: element.titleLabel)
             text.apply(to: element.textField)
             content.apply(to: element.contentView)
-        }
-    }
-}
-
-extension Component.TextInput {
-
-    public enum Accessory {
-        case icon(UIImage)
-        case none
-
-        fileprivate var toAccessoryViewAccessory: AccessoryView.Accessory {
-            switch self {
-            case let .icon(image):
-                return .icon(image)
-            case .none:
-                return .none
-            }
         }
     }
 }

--- a/BentoKit/BentoKit/Components/TextInput.swift
+++ b/BentoKit/BentoKit/Components/TextInput.swift
@@ -4,6 +4,7 @@ import Foundation
 
 extension Component {
     public final class TextInput: AutoRenderable, Focusable {
+        public typealias Accessory = FocusTextField.Accessory
 
         public let configurator: (View) -> Void
         public let styleSheet: StyleSheet
@@ -108,7 +109,7 @@ extension Component.TextInput {
     public final class StyleSheet: BaseViewStyleSheet<View> {
         public var titleStyle: View.TitleStyle
         public let title: LabelStyleSheet
-        public let text: FocusTextField.StyleSheet
+        public let text: TextFieldStylesheet
         public let content: ViewStyleSheet<UIView>
 
         public init(
@@ -117,7 +118,7 @@ extension Component.TextInput {
                 font: UIFont.preferredFont(forTextStyle: .body),
                 textAlignment: .leading
             ),
-            text: FocusTextField.StyleSheet = FocusTextField.StyleSheet(),
+            text: TextFieldStylesheet = TextFieldStylesheet(),
             content: ViewStyleSheet<UIView> = ViewStyleSheet(layoutMargins: .zero)
         ) {
             self.titleStyle = titleStyle
@@ -130,7 +131,7 @@ extension Component.TextInput {
             super.apply(to: element)
             element.titleStyle = titleStyle
             title.apply(to: element.titleLabel)
-            text.apply(to: element.textField)
+            text.apply(to: element.textField.textField)
             content.apply(to: element.contentView)
         }
     }

--- a/BentoKit/BentoKit/Views/FocusTextField.swift
+++ b/BentoKit/BentoKit/Views/FocusTextField.swift
@@ -1,0 +1,132 @@
+import UIKit
+import Bento
+import StyleSheets
+
+public final class FocusTextField: UIView, UITextFieldDelegate {
+    public let accessoryView = AccessoryView()
+    public let textField = UITextField()
+
+    var textWillChange: Optional<(TextChange) -> Bool> = nil
+    var textDidChange: Optional<(String?) -> Void> = nil
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    private func setupLayout() {
+        stack(.horizontal, spacing: 16, distribution: .fill, alignment: .center)(
+            textField, accessoryView
+            )
+            .add(to: self)
+            .pinEdges(to: self)
+
+        textField.addTarget(self, action: #selector(textDidChangeOn(_:)), for: UIControl.Event.editingChanged)
+        textField.delegate = self
+    }
+
+    @available(*, unavailable)
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func textDidChangeOn(_ textField: UITextField) {
+        self.textDidChange?(textField.text)
+    }
+
+    @objc public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        return textWillChange?(
+            .init(current: textField.text, change: string, range: range)
+            ) ?? true
+    }
+
+    @objc public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        withFocusCoordinator { coordinator in
+            if !coordinator.move(.backward) {
+                textField.resignFirstResponder()
+            }
+        }
+
+        return false
+    }
+
+    @objc public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        updateReturnKey()
+        textField.inputAccessoryView = FocusToolbar(view: self)
+        return true
+    }
+
+    public func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
+        textField.inputAccessoryView = nil
+    }
+
+    private func updateReturnKey() {
+        withFocusCoordinator { coordinator in
+            let usesNextKey = coordinator.canMove(.backward)
+            textField.returnKeyType = usesNextKey ? .next : .done
+        }
+    }
+}
+
+
+extension FocusTextField: FocusableView {
+    public func focus() {
+        textField.becomeFirstResponder()
+    }
+
+    public func neighboringFocusEligibilityDidChange() {
+        updateReturnKey()
+        (textField.inputAccessoryView as? FocusToolbar)?.updateFocusEligibility(with: self)
+        textField.reloadInputViews()
+    }
+}
+
+extension FocusTextField {
+    public struct TextChange {
+        public let current: String?
+        public let change: String
+        public let range: NSRange
+
+        public var result: String {
+            guard let current = self.current,
+                let range = Range(range, in: current)
+                else { return "" }
+
+            return current.replacingCharacters(in: range, with: change)
+        }
+    }
+}
+
+extension FocusTextField {
+
+    public enum Accessory {
+        case icon(UIImage)
+        case none
+
+        public var toAccessoryViewAccessory: AccessoryView.Accessory {
+            switch self {
+            case let .icon(image):
+                return .icon(image)
+            case .none:
+                return .none
+            }
+        }
+    }
+}
+
+extension FocusTextField {
+    public final class StyleSheet: ViewStyleSheet<FocusTextField> {
+        public let text: TextFieldStylesheet
+
+        public init(
+            text: TextFieldStylesheet = TextFieldStylesheet()
+            ) {
+            self.text = text
+        }
+
+        public override func apply(to element: FocusTextField) {
+            super.apply(to: element)
+            text.apply(to: element.textField)
+        }
+    }
+}

--- a/BentoKit/BentoKit/Views/FocusTextField.swift
+++ b/BentoKit/BentoKit/Views/FocusTextField.swift
@@ -6,8 +6,10 @@ public final class FocusTextField: UIView, UITextFieldDelegate {
     public let accessoryView = AccessoryView()
     public let textField = UITextField()
 
-    var textWillChange: Optional<(TextChange) -> Bool> = nil
-    var textDidChange: Optional<(String?) -> Void> = nil
+    public var textWillChange: Optional<(TextChange) -> Bool> = nil
+    public var textDidChange: Optional<(String?) -> Void> = nil
+    public var didBeginEditing: (() -> ())?
+    public var didEndEditing: (() -> ())?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -53,11 +55,17 @@ public final class FocusTextField: UIView, UITextFieldDelegate {
     @objc public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         updateReturnKey()
         textField.inputAccessoryView = FocusToolbar(view: self)
+        didBeginEditing?()
         return true
     }
 
     public func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
         textField.inputAccessoryView = nil
+        didEndEditing?()
+    }
+
+    public override func becomeFirstResponder() -> Bool {
+        return textField.becomeFirstResponder()
     }
 
     private func updateReturnKey() {
@@ -110,23 +118,6 @@ extension FocusTextField {
             case .none:
                 return .none
             }
-        }
-    }
-}
-
-extension FocusTextField {
-    public final class StyleSheet: ViewStyleSheet<FocusTextField> {
-        public let text: TextFieldStylesheet
-
-        public init(
-            text: TextFieldStylesheet = TextFieldStylesheet()
-            ) {
-            self.text = text
-        }
-
-        public override func apply(to element: FocusTextField) {
-            super.apply(to: element)
-            text.apply(to: element.textField)
         }
     }
 }


### PR DESCRIPTION
Currently it's not easy to reuse `Components.TextInput`.

This PR introduces `FocusTextField` which contains a `UITextField` and an `AccessoryView`.
The idea is to have compassable views in order to create new components which will be needed.

These changes are source compatible for the consumers of `Components.TextInput`