### PR TITLE
Fix button component having multiple buttons

### DIFF
--- a/BentoKit/BentoKit/Components/Button.swift
+++ b/BentoKit/BentoKit/Components/Button.swift
@@ -75,6 +75,9 @@ extension Component.Button {
             didSet {
                 guard oldValue != buttonType else { return }
 
+                activityIndicator.removeFromSuperview()
+                button.removeFromSuperview()
+
                 button = Button(type: buttonType)
                 button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
 
@@ -119,9 +122,6 @@ extension Component.Button {
         }
 
         private func setupLayout() {
-            activityIndicator.removeFromSuperview()
-            button.removeFromSuperview()
-
             button
                 .add(to: self)
                 .pinTop(to: layoutMarginsGuide)


### PR DESCRIPTION
Fixes a bug introduced in #99 which means that when the `buttonType` is changed, the old button is not removed from the component view before adding the new button, resulting in two (or more) buttons being added to the component.