### PR TITLE
Fix bug for multiline button text

### DIFF
--- a/BentoKit/BentoKit/Components/Button.swift
+++ b/BentoKit/BentoKit/Components/Button.swift
@@ -151,11 +151,9 @@ extension Component.Button {
                 case (.leading, _),
                      (.center, false):
                     return button.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor)
-                        .withPriority(.defaultHigh)
                 case (.trailing, _),
                      (.center, true):
                     return button.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor)
-                        .withPriority(.defaultHigh)
                 }
             }()
 
@@ -164,11 +162,9 @@ extension Component.Button {
                 case (.leading, _),
                      (.center, true):
                     return layoutMarginsGuide.trailingAnchor.constraint(greaterThanOrEqualTo: button.trailingAnchor)
-                        .withPriority(.defaultHigh)
                 case (.trailing, _),
                      (.center, false):
                     return layoutMarginsGuide.trailingAnchor.constraint(equalTo: button.trailingAnchor)
-                        .withPriority(.defaultHigh)
                 }
             }()
 

--- a/BentoKit/BentoKitTests/SnapshotTests/Components/ButtonComponentSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/ButtonComponentSnapshotTests.swift
@@ -49,7 +49,7 @@ final class ButtonComponentSnapshotTests: SnapshotTestCase {
             .compose(\.backgroundColor, .cyan)
             .compose(\.button.numberOfLines, 0)
 
-        let longText = Array(repeating: "Long Text", count: 8).joined()
+        let longText = Array(repeating: "Long Text ", count: 16).joined()
 
         let component = Component.Button(
             title: longText,

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_multiline_button_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_multiline_button_iPhone6@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1c0ec78cf63bef9db7743595118e4d187c3a271a55c81f55bbb670820603d09
-size 30139
+oid sha256:022703608e0416b4ed01acf2db7ae6aa25485dbfb0f6c4f6ddd78652c5231c04
+size 37821

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_multiline_button_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_multiline_button_iPhone6Plus@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5660f445b8e4ab201b463f1cb22045a032502c6aecbb5c97763a85dfef04d0ad
-size 34453
+oid sha256:bbd79addc4c2c4f706147083fce4ce5d3eddcf117a81283f0dd5fa3f0f82c707
+size 42425

--- a/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_multiline_button_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.ButtonComponentSnapshotTests/test_multiline_button_iPhoneX@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d21972c43ddef79d887ece8bf67ce865c4c2beeb2cdb2f2e1bd9dd9fe89ca998
-size 34955
+oid sha256:1403cd98d75cdfe0d490cc45bf438f4525a10bff0e1f3284fd02f17e37c57c41
+size 42576


### PR DESCRIPTION
We were using `.defaultHigh` priority for the horizontal constraints, which allows a long text string to expand the button width. This was not showing up in snapshot tests as 2 lines of text still fitted in the standard cell height 🤦‍♂️ 