### PR TITLE
Remove `If<T>` & `Some<T, U>`

### DIFF
--- a/Bento/Bento/If.swift
+++ b/Bento/Bento/If.swift
@@ -1,5 +1,5 @@
 extension Optional {
-    public static func iff(_ condition: @autoclosure @escaping () -> Bool, _ generator: @autoclosure @escaping () -> Wrapped) -> Wrapped? {
+    public static func iff(_ condition: @autoclosure () -> Bool, _ generator: @autoclosure () -> Wrapped) -> Wrapped? {
         if condition() {
             return generator()
         } else {
@@ -7,7 +7,7 @@ extension Optional {
         }
     }
 
-    public static func iff(_ condition: @autoclosure @escaping () -> Bool, _ generator: @escaping () -> Wrapped) -> Wrapped? {
+    public static func iff(_ condition: @autoclosure () -> Bool, _ generator: () -> Wrapped) -> Wrapped? {
         if condition() {
             return generator()
         } else {
@@ -15,7 +15,7 @@ extension Optional {
         }
     }
 
-    public static func iff(_ condition: @escaping () -> Bool, _ generator: @escaping () -> Wrapped) -> Wrapped? {
+    public static func iff(_ condition: () -> Bool, _ generator: () -> Wrapped) -> Wrapped? {
         if condition() {
             return generator()
         } else {

--- a/Bento/Bento/If.swift
+++ b/Bento/Bento/If.swift
@@ -1,99 +1,69 @@
-public struct If<T> {
-    let condition: () -> Bool
-    let generator: () -> T
-
-    public static func iff(_ condition: @autoclosure @escaping () -> Bool, _ generator: @autoclosure @escaping () -> T) -> If<T> {
-        return If(condition: condition, generator: generator)
+extension Optional {
+    public static func iff(_ condition: @autoclosure @escaping () -> Bool, _ generator: @autoclosure @escaping () -> Wrapped) -> Wrapped? {
+        if condition() {
+            return generator()
+        } else {
+            return .none
+        }
     }
 
-    public static func iff(_ condition: @autoclosure @escaping () -> Bool, _ generator: @escaping () -> T) -> If<T> {
-        return If(condition: condition, generator: generator)
+    public static func iff(_ condition: @autoclosure @escaping () -> Bool, _ generator: @escaping () -> Wrapped) -> Wrapped? {
+        if condition() {
+            return generator()
+        } else {
+            return .none
+        }
     }
 
-    public static func iff(_ condition: @escaping () -> Bool, _ generator: @escaping () -> T) -> If<T> {
-        return If(condition: condition, generator: generator)
-    }
-}
-
-public struct Some<T, U> {
-    let optional: T?
-    let generator: (T) -> U
-
-    public static func some(_ optional: T?, _ generator: @escaping (T) -> U) -> Some<T, U> {
-        return Some(optional: optional, generator: generator)
+    public static func iff(_ condition: @escaping () -> Bool, _ generator: @escaping () -> Wrapped) -> Wrapped? {
+        if condition() {
+            return generator()
+        } else {
+            return .none
+        }
     }
 }
 
 extension Section {
-    public static func |---? (lhs: Section, rhs: If<Item>) -> Section {
-        if rhs.condition() {
+    public static func |---? (lhs: Section, rhs: Item?) -> Section {
+        if let item = rhs {
+            return lhs |---+ item
+        } else {
             return lhs
-                |---+ rhs.generator()
         }
-        return lhs
     }
 
-    public static func |---? (lhs: Section, rhs: If<[Item]>) -> Section {
-        if rhs.condition() {
+    public static func |---? (lhs: Section, rhs: [Item]?) -> Section {
+        if let items = rhs {
+            return lhs |---* items
+        } else {
             return lhs
-                |---* rhs.generator()
         }
-        return lhs
-    }
-
-    public static func |---? <T>(lhs: Section, rhs: Some<T, Item>) -> Section {
-        return rhs.optional.map { value in
-            lhs |---+ rhs.generator(value)
-        } ?? lhs
-    }
-
-    public static func |---? <T>(lhs: Section, rhs: Some<T, [Item]>) -> Section {
-        return rhs.optional.map { value in
-            lhs |---* rhs.generator(value)
-        } ?? lhs
     }
 }
 
 extension Box {
-    public static func |-? (lhs: Box, rhs: If<Section>) -> Box {
-        if rhs.condition() {
+    public static func |-? (lhs: Box, rhs: Section?) -> Box {
+        if let section = rhs {
+            return lhs |-+ section
+        } else {
             return lhs
-                |-+ rhs.generator()
         }
+    }
+}
+
+public func |---?<Identifier>(lhs: Node<Identifier>, rhs: Node<Identifier>?) -> [Node<Identifier>] {
+    if let node = rhs {
+        return [lhs, node]
+    } else {
+        return [lhs]
+    }
+}
+
+public func |---?<Identifier>(lhs: [Node<Identifier>], rhs: Node<Identifier>?) -> [Node<Identifier>] {
+    if let node = rhs {
+        return lhs + [node]
+    } else {
         return lhs
     }
-
-    public static func |-? <T>(lhs: Box, rhs: Some<T, Section>) -> Box {
-        return rhs.optional.map { value in
-            lhs |-+ rhs.generator(value)
-        } ?? lhs
-    }
-}
-
-public func |---?<Identifier>(lhs: Node<Identifier>, rhs: If<Node<Identifier>>) -> [Node<Identifier>] {
-    if rhs.condition() {
-        return [lhs, rhs.generator()]
-    }
-
-    return [lhs]
-}
-
-public func |---?<Identifier>(lhs: [Node<Identifier>], rhs: If<Node<Identifier>>) -> [Node<Identifier>] {
-    if rhs.condition() {
-        return lhs + [rhs.generator()]
-    }
-
-    return lhs
-}
-
-public func |---?<T, Identifier>(lhs: Node<Identifier>, rhs: Some<T, Node<Identifier>>) -> [Node<Identifier>] {
-    return rhs.optional.map { value in
-        [lhs, rhs.generator(value)]
-        } ?? [lhs]
-}
-
-public func |---?<T, Identifier>(lhs: [Node<Identifier>], rhs: Some<T, Node<Identifier>>) -> [Node<Identifier>] {
-    return rhs.optional.map { value in
-        lhs + [rhs.generator(value)]
-        } ?? lhs
 }

--- a/BentoTests/ConcatenationTests.swift
+++ b/BentoTests/ConcatenationTests.swift
@@ -19,7 +19,7 @@ class ConcatenationTests: XCTestCase {
         let optional: String? = nil
 
         let box = Box<TestSectionId, TestRowId>.empty
-            |-? .some(optional) { _ in
+            |-? optional.map { _ in
                 section
             }
 
@@ -31,7 +31,7 @@ class ConcatenationTests: XCTestCase {
         let optional: String? = "something"
 
         let box = Box<TestSectionId, TestRowId>.empty
-            |-? .some(optional) { _ in
+            |-? optional.map { _ in
                 section
             }
 
@@ -56,7 +56,7 @@ class ConcatenationTests: XCTestCase {
         let optional: String? = nil
 
         let result: Section<TestSectionId, TestRowId> = section
-            |---? .some(optional) { _ in
+            |---? optional.map { _ in
                 node
             }
 
@@ -70,7 +70,7 @@ class ConcatenationTests: XCTestCase {
         let optional: String? = "something"
 
         let result: Section<TestSectionId, TestRowId> = section
-            |---? .some(optional) { _ in
+            |---? optional.map { _ in
                 node
             }
 


### PR DESCRIPTION
**Note: Breaking change.**

This PR removes `If<T>` and `Some<T, U>` types as discussed in https://github.com/Babylonpartners/Bento/pull/123#issuecomment-471929681 by using plain `Optional` instead.
