### PR TITLE
Use `.center` content mode of accessory view

### DIFF
--- a/BentoKit/BentoKit/Views/Accessory.swift
+++ b/BentoKit/BentoKit/Views/Accessory.swift
@@ -22,7 +22,7 @@ public final class AccessoryView: InteractiveView {
         didSet {
             oldValue?.removeFromSuperview()
 
-            view?.contentMode = .scaleAspectFit
+            view?.contentMode = .center
             view?.translatesAutoresizingMaskIntoConstraints = false
             view?.add(to: self)
                 .pinEdges(to: self)


### PR DESCRIPTION
## Description

It seems like there is an issue with how accessory view is rendering its content when content mode is not `.center`

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 5s - 2019-03-15 at 15 48 57](https://user-images.githubusercontent.com/4622322/54446383-b616c200-473e-11e9-9c8d-865bd171794b.png)| ![Simulator Screen Shot - iPhone 5s - 2019-03-15 at 15 46 16](https://user-images.githubusercontent.com/4622322/54446397-bdd66680-473e-11e9-9afc-fb5ea782fd50.png) |