### PR TITLE
Removes deprecated init

### DIFF
--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -34,54 +34,6 @@ public extension Component {
             return heightComputer(width, inheritedMargins)
         }
 
-        @available(*, deprecated, message: "Please use the designated initialiser.")
-        public convenience init(
-            title: String,
-            attributedText: NSAttributedString? = nil,
-            subtitle: String? = nil,
-            detail: String? = nil,
-            image: Property<BentoKit.ImageOrLabel>? = nil,
-            accessory: Accessory = .chevron,
-            badgeIcon: UIImage? = nil,
-            inputNodes: CustomInput? = nil,
-            didTap: Optional<() -> Void> = nil,
-            didTapAccessory: Optional<() -> Void> = nil,
-            styleSheet: StyleSheet = .init()
-        ) {
-            let titleText: TextValue
-            if let attributedText = attributedText {
-                titleText = .rich(attributedText)
-            } else {
-                titleText = .plain(title)
-            }
-
-            let texts: [TextValue]
-            if let subtitle = subtitle {
-                texts = [titleText, .plain(subtitle)]
-            } else {
-                texts = [titleText]
-            }
-
-            let detailText: TextValue?
-            if let detail = detail {
-                detailText = TextValue.plain(detail)
-            } else {
-                detailText = nil
-            }
-
-            self.init(
-                texts: texts,
-                detail: detailText,
-                image: image,
-                accessory: accessory,
-                badgeIcon: badgeIcon,
-                inputNodes: inputNodes,
-                didTap: didTap,
-                didTapAccessory: didTapAccessory,
-                styleSheet: styleSheet
-            )
-        }
-
         public init(
             texts: [TextValue] = [],
             detail: TextValue? = nil,

--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -494,56 +494,6 @@ public extension Component.TitledDescription {
         public let badge: ViewStyleSheet<UIView>
         public let accessory: InteractiveViewStyleSheet<InteractiveView>
 
-        @available(*, deprecated, message: "Please use textBlockWidthFraction.")
-        public var titleWidthFraction: CGFloat? {
-            get { return textBlockWidthFraction }
-            set { textBlockWidthFraction = newValue }
-        }
-
-        @available(*, deprecated, message: "Please use textStyles.")
-        public var title: LabelStyleSheet {
-            get { return textStyles[0] }
-            set { textStyles[0] = newValue }
-        }
-
-        @available(*, deprecated, message: "Please use textStyles.")
-        public var subtitle: LabelStyleSheet {
-            get { return textStyles[1] }
-            set { textStyles[1] = newValue }
-        }
-        @available(*, deprecated, message: "Please use the designated initialiser.")
-        public convenience init(
-            verticalSpacingBetweenElements: CGFloat = 8.0,
-            titleWidthFraction: CGFloat? = nil,
-            highlightingTarget: HighlightingTarget = HighlightingTarget.container,
-            badgeOffset: CGPoint = .zero,
-            badgeSize: CGSize = CGSize(width: 12, height: 12),
-            enforcesMinimumHeight: Bool = true,
-            content: ContentStyleSheet = .init(),
-            imageOrLabel: ImageOrLabelView.StyleSheet = .init(),
-            title: LabelStyleSheet = .init(),
-            subtitle: LabelStyleSheet = .init(font: UIFont.preferredFont(forTextStyle: .footnote),
-                                              textColor: .gray),
-            detail: LabelStyleSheet = .init(textAlignment: .trailing),
-            badge: ViewStyleSheet<UIView> = ViewStyleSheet<UIView>(),
-            accessory: InteractiveViewStyleSheet<InteractiveView> = InteractiveViewStyleSheet<InteractiveView>()
-        ) {
-            self.init(
-                verticalSpacingBetweenElements: verticalSpacingBetweenElements,
-                textBlockWidthFraction: titleWidthFraction,
-                highlightingTarget: highlightingTarget,
-                badgeOffset: badgeOffset,
-                badgeSize: badgeSize,
-                enforcesMinimumHeight: enforcesMinimumHeight,
-                content: content,
-                imageOrLabel: imageOrLabel,
-                textStyles: [title, subtitle],
-                detail: detail,
-                badge: badge,
-                accessory: accessory
-            )
-        }
-
         public init(
             verticalSpacingBetweenElements: CGFloat = 8.0,
             textBlockWidthFraction: CGFloat? = nil,

--- a/BentoKit/BentoKitTests/SnapshotTests/Components/TitledDescriptionLegacySnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Components/TitledDescriptionLegacySnapshotTests.swift
@@ -7,9 +7,16 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     var styleSheet: Component.TitledDescription.StyleSheet {
         return Component.TitledDescription.StyleSheet(
-            title: LabelStyleSheet(
-                backgroundColor: .blue,
-                font: UIFont.preferredFont(forTextStyle: .body)),
+            textStyles: [
+                LabelStyleSheet(
+                    backgroundColor: .blue,
+                    font: UIFont.preferredFont(forTextStyle: .body)
+                ),
+                LabelStyleSheet(
+                    font: UIFont.preferredFont(forTextStyle: .footnote),
+                    textColor: .gray
+                )
+            ],
             detail: LabelStyleSheet(
                 backgroundColor: .green,
                 font: UIFont.preferredFont(forTextStyle: .body),
@@ -24,9 +31,8 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     func test_has_chevron() {
         let component = Component.TitledDescription(
-            title: "Title",
-            subtitle: "Subtitle",
-            detail: "Detail",
+            texts: ["Title", "Subtitle"].map(TextValue.plain),
+            detail: TextValue.plain("Detail"),
             accessory: .chevron,
             styleSheet: styleSheet
         )
@@ -36,9 +42,8 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     func test_no_chevron() {
         let component = Component.TitledDescription(
-            title: "Title",
-            subtitle: "Subtitle",
-            detail: "Detail",
+            texts: ["Title", "Subtitle"].map(TextValue.plain),
+            detail: TextValue.plain("Detail"),
             accessory: .none,
             styleSheet: styleSheet
         )
@@ -48,9 +53,8 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     func test_is_loading() {
         let component = Component.TitledDescription(
-            title: "Title",
-            subtitle: "Subtitle",
-            detail: "Detail",
+            texts: ["Title", "Subtitle"].map(TextValue.plain),
+            detail: TextValue.plain("Detail"),
             accessory: .activityIndicator,
             didTap: {},
             styleSheet: styleSheet
@@ -61,9 +65,8 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     func test_has_checkmark() {
         let component = Component.TitledDescription(
-            title: "Title",
-            subtitle: "Subtitle",
-            detail: "Detail",
+            texts: ["Title", "Subtitle"].map(TextValue.plain),
+            detail: TextValue.plain("Detail"),
             accessory: .checkmark,
             styleSheet: styleSheet
         )
@@ -73,9 +76,8 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     func test_has_icon() {
         let component = Component.TitledDescription(
-            title: "Title",
-            subtitle: "Subtitle",
-            detail: "Detail",
+            texts: ["Title", "Subtitle"].map(TextValue.plain),
+            detail: TextValue.plain("Detail"),
             accessory: .icon(image(named: "plus")),
             styleSheet: styleSheet
         )
@@ -85,9 +87,8 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     func test_has_image_fixed_size() {
         let component = Component.TitledDescription(
-            title: "Title",
-            subtitle: "Subtitle",
-            detail: "Detail",
+            texts: ["Title", "Subtitle"].map(TextValue.plain),
+            detail: TextValue.plain("Detail"),
             image: Property(value: .image(image(named: "skeleton"))),
             styleSheet: styleSheet
                 .compose(\.imageOrLabel.fixedSize, CGSize(width: 128, height: 128))
@@ -100,9 +101,8 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     func test_has_text_image_placeholder() {
         let component = Component.TitledDescription(
-            title: "Title",
-            subtitle: "Subtitle",
-            detail: "Detail",
+            texts: ["Title", "Subtitle"].map(TextValue.plain),
+            detail: TextValue.plain("Detail"),
             image: Property(value: .text("SJ")),
             styleSheet: styleSheet
                 .compose(\.imageOrLabel.fixedSize, CGSize(width: 64, height: 64))
@@ -118,11 +118,11 @@ final class TitledDescriptionLegacySnapshotTests: SnapshotTestCase {
 
     func test_fixed_title_width() {
         let component = Component.TitledDescription(
-            title: "Title",
-            detail: "Detail",
+            texts: ["Title"].map(TextValue.plain),
+            detail: TextValue.plain("Detail"),
             accessory: .chevron,
             styleSheet: styleSheet
-                .compose(\.titleWidthFraction, 0.3)
+                .compose(\.textBlockWidthFraction, 0.3)
                 .compose(\.detail.textAlignment, .leading)
         )
 


### PR DESCRIPTION
Removes deprecated init of TiteledDescription as this will be the first release of BentoKit.
There's no reason to keep a depreceted code.