### PR TITLE
Improve documentation for `BentoReusableView`

### DIFF
--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -1,4 +1,4 @@
-/// Existential type for reusable views (cell, header, footer) in `UITableView`, `UICollectionView`, etc.
+/// Protocol for reusable views (cell, header, footer) in `UITableView`, `UICollectionView`, etc.
 protocol BentoReusableView: AnyObject {
     /// The view to which `containedView` should be added.
     /// - Note: This is normally system-provided as `self`'s subview.

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -14,7 +14,7 @@ protocol BentoReusableView: AnyObject {
 }
 
 extension BentoReusableView {
-    /// Updates `component` to either replace `containedView` with a new one or reuse it.
+    /// Uses `component` to either replace `containedView` with a new one or reuse it.
     func bind(_ component: AnyRenderable?) {
         self.component = component
         if let component = component {

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -1,6 +1,6 @@
 /// Existential type for reusable views (cell, header, footer) in `UITableView`, `UICollectionView`, etc.
 protocol BentoReusableView: AnyObject {
-    /// The main view to which you add your reusable view’s custom content.
+    /// The view to which `containedView` should be added.
     /// - Note: This is normally system-provided as `self`'s subview.
     var contentView: UIView { get }
 

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -5,7 +5,7 @@ protocol BentoReusableView: AnyObject {
     var contentView: UIView { get }
 
     /// `component`-generated view that will be added to `contentView`.
-    /// - Note: Subtype of this instance can conforming to `ViewLifecycleAware` to allow display handling.
+    /// - Note: Subtype of this instance can conform to `ViewLifecycleAware` to allow display handling.
     var containedView: UIView? { get set }
 
     /// A renderer which generates `containedView`.

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -1,10 +1,20 @@
+/// Existential type for reusable views (cell, header, footer) in `UITableView`, `UICollectionView`, etc.
 protocol BentoReusableView: AnyObject {
-    var containedView: UIView? { get set }
+    /// The main view to which you add your reusable view’s custom content.
+    /// - Note: This is normally system-provided as `self`'s subview.
     var contentView: UIView { get }
+
+    /// `component`-generated view that will be added to `contentView`.
+    /// - Note: Subtype of this instance can conforming to `ViewLifecycleAware` to allow display handling.
+    var containedView: UIView? { get set }
+
+    /// A renderer which generates `containedView`.
+    /// - Note: Underlying type of this instance can conform to `ComponentLifecycleAware` to allow display handling.
     var component: AnyRenderable? { get set }
 }
 
 extension BentoReusableView {
+    /// Updates `component` to either replace `containedView` with a new one or reuse it.
     func bind(_ component: AnyRenderable?) {
         self.component = component
         if let component = component {
@@ -39,7 +49,8 @@ extension BentoReusableView {
 }
 
 extension BentoReusableView where Self: UIView {
-    func containerViewDidChange(from old: UIView?, to new: UIView?) {
+    /// - Note: Call this method when old `containedView` is replaced with new one.
+    func containedViewDidChange(from old: UIView?, to new: UIView?) {
         func add(_ view: UIView) {
             contentView.addSubview(view)
             view.pinToEdges(of: contentView)

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -9,7 +9,7 @@ protocol BentoReusableView: AnyObject {
     var containedView: UIView? { get set }
 
     /// A renderer which generates `containedView`.
-    /// - Note: Underlying type of this instance can conform to `ComponentLifecycleAware` to allow display handling.
+    /// - note: Underlying type of this instance can conform to `ComponentLifecycleAware` to allow display handling.
     var component: AnyRenderable? { get set }
 }
 

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -49,7 +49,7 @@ extension BentoReusableView {
 }
 
 extension BentoReusableView where Self: UIView {
-    /// - Note: Call this method when old `containedView` is replaced with new one.
+    /// - important: This should be invoked whenever `containedView` is changed.
     func containedViewDidChange(from old: UIView?, to new: UIView?) {
         func add(_ view: UIView) {
             contentView.addSubview(view)

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -4,7 +4,9 @@ protocol BentoReusableView: AnyObject {
     /// - Note: This is normally system-provided as `self`'s subview.
     var contentView: UIView { get }
 
-    /// `component`-generated view that will be added to `contentView`.
+    /// The component root view that is currently added in `contentView`.
+    /// If the existing view is no longer compatible with the newly set `component`,
+    /// a new compatible view should be instantiated to replace it.
     /// - Note: Subtype of this instance can conform to `ViewLifecycleAware` to allow display handling.
     var containedView: UIView? { get set }
 

--- a/Bento/Views/CollectionViewContainerCell.swift
+++ b/Bento/Views/CollectionViewContainerCell.swift
@@ -3,7 +3,7 @@ import UIKit
 final class CollectionViewContainerCell: UICollectionViewCell {
     var containedView: UIView? {
         didSet {
-            containerViewDidChange(from: oldValue, to: containedView)
+            containedViewDidChange(from: oldValue, to: containedView)
         }
     }
 

--- a/Bento/Views/CollectionViewContainerReusableView.swift
+++ b/Bento/Views/CollectionViewContainerReusableView.swift
@@ -3,7 +3,7 @@ import UIKit
 final class CollectionViewContainerReusableView: UICollectionReusableView {
     var containedView: UIView? {
         didSet {
-            containerViewDidChange(from: oldValue, to: containedView)
+            containedViewDidChange(from: oldValue, to: containedView)
         }
     }
 

--- a/Bento/Views/TableViewContainerCell.swift
+++ b/Bento/Views/TableViewContainerCell.swift
@@ -3,7 +3,7 @@ import UIKit
 final class TableViewContainerCell: UITableViewCell {
     var containedView: UIView? {
         didSet {
-            containerViewDidChange(from: oldValue, to: containedView)
+            containedViewDidChange(from: oldValue, to: containedView)
         }
     }
 

--- a/Bento/Views/TableViewHeaderFooterView.swift
+++ b/Bento/Views/TableViewHeaderFooterView.swift
@@ -3,7 +3,7 @@ import UIKit
 final class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     var containedView: UIView? {
         didSet {
-            containerViewDidChange(from: oldValue, to: containedView)
+            containedViewDidChange(from: oldValue, to: containedView)
         }
     }
 


### PR DESCRIPTION
This PR improves documentation for `BentoReusableView` as follows:

- Distinguishes terminology between `contentView` and `containedView`
- Describes the relationship with `ViewLifecycleAware` and `ComponentLifecycleAware`
- Renames internal method for readability