### PR TITLE
Upgrade BoxViewController to use the size caching BoxViewController.

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		65E3ECAC2113591500869DF3 /* FocusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECAB2113591500869DF3 /* FocusableView.swift */; };
 		65E3ECAE2113594600869DF3 /* BentoCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECAD2113594600869DF3 /* BentoCollectionView.swift */; };
 		65E3ECB02113598700869DF3 /* UIKit+BentoCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E3ECAF2113598700869DF3 /* UIKit+BentoCollectionView.swift */; };
+		65E4D8B6225D009500CA7CB3 /* SizeCachingTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4D8B5225D009500CA7CB3 /* SizeCachingTableView.swift */; };
 		740921B620ACDDDA00B59F5C /* IfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740921B520ACDDDA00B59F5C /* IfTests.swift */; };
 		740921B820ACE5EC00B59F5C /* ConcatenationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740921B720ACE5EC00B59F5C /* ConcatenationTests.swift */; };
 		74208FA12083B1F00062CC8D /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74208FA22083B1F00062CC8D /* Nimble.framework */; };
@@ -209,6 +210,7 @@
 		65E3ECAB2113591500869DF3 /* FocusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusableView.swift; sourceTree = "<group>"; };
 		65E3ECAD2113594600869DF3 /* BentoCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BentoCollectionView.swift; sourceTree = "<group>"; };
 		65E3ECAF2113598700869DF3 /* UIKit+BentoCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIKit+BentoCollectionView.swift"; sourceTree = "<group>"; };
+		65E4D8B5225D009500CA7CB3 /* SizeCachingTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SizeCachingTableView.swift; sourceTree = "<group>"; };
 		740921B520ACDDDA00B59F5C /* IfTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfTests.swift; sourceTree = "<group>"; };
 		740921B720ACE5EC00B59F5C /* ConcatenationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcatenationTests.swift; sourceTree = "<group>"; };
 		74208FA22083B1F00062CC8D /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -382,6 +384,7 @@
 		58BA755D2016303B0050D5F1 /* Bento */ = {
 			isa = PBXGroup;
 			children = (
+				65E4D8B4225D009500CA7CB3 /* CollectionViews+Public */,
 				581ED77E2022041C00EC9584 /* Diff */,
 				587F0716201B354900ACD219 /* Views */,
 				58E98E612018898700F78BAE /* Renderable */,
@@ -463,6 +466,14 @@
 				65A69EE0218B8AB6005D90AC /* CustomCollectionViewAdapter.swift */,
 			);
 			path = CollectionViewExample;
+			sourceTree = "<group>";
+		};
+		65E4D8B4225D009500CA7CB3 /* CollectionViews+Public */ = {
+			isa = PBXGroup;
+			children = (
+				65E4D8B5225D009500CA7CB3 /* SizeCachingTableView.swift */,
+			);
+			path = "CollectionViews+Public";
 			sourceTree = "<group>";
 		};
 		7D7D5AFB203495BA731D7A3E /* Frameworks */ = {
@@ -725,6 +736,7 @@
 				5B02B99422503A370089371A /* AdapterStore.swift in Sources */,
 				5857BECA2056F02C0085EB9C /* If.swift in Sources */,
 				A9509FB12CAD89179FAA03B0 /* Box.swift in Sources */,
+				65E4D8B6225D009500CA7CB3 /* SizeCachingTableView.swift in Sources */,
 				582D9987217F87B100C67B0D /* ComponentLifecycleAware.swift in Sources */,
 				65E3ECA621133C9400869DF3 /* UIKit+CollectionViewFocus.swift in Sources */,
 				58467B03202B33F200577C77 /* TableViewSectionDiff.swift in Sources */,

--- a/BentoKit/BentoKit.xcodeproj/project.pbxproj
+++ b/BentoKit/BentoKit.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		588011A02162740C0084EE07 /* FBSnapshotTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5880119F2162740C0084EE07 /* FBSnapshotTestCaseExtensions.swift */; };
 		58ADAF72215E602E00B143F5 /* UIImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ADAF71215E602E00B143F5 /* UIImageExtensions.swift */; };
 		65020C3022030CB000DC8F42 /* InteractionBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65020C2F22030CB000DC8F42 /* InteractionBehavior.swift */; };
+		65E4D8B3225D006300CA7CB3 /* BoxSizeCachingTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4D8B2225D006300CA7CB3 /* BoxSizeCachingTableView.swift */; };
 		7421E0282192D9B70014F631 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7421E0272192D9B70014F631 /* Resources.swift */; };
 		A6113A7E2180CD0100C6DB5A /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6113A7D2180CD0100C6DB5A /* FBSnapshotTestCase.framework */; };
 		A6EC2DAE218B28AA002B128F /* BoxAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6EC2DA9218B28AA002B128F /* BoxAppearance.swift */; };
@@ -172,6 +173,7 @@
 		58ADAF71215E602E00B143F5 /* UIImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtensions.swift; sourceTree = "<group>"; };
 		639430F94D2A3AB0B5FBBFF0 /* Pods_BentoKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BentoKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65020C2F22030CB000DC8F42 /* InteractionBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionBehavior.swift; sourceTree = "<group>"; };
+		65E4D8B2225D006300CA7CB3 /* BoxSizeCachingTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoxSizeCachingTableView.swift; sourceTree = "<group>"; };
 		7421E0272192D9B70014F631 /* Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resources.swift; sourceTree = "<group>"; };
 		A6113A7A2180C87400C6DB5A /* Framework.Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.Debug.xcconfig; sourceTree = "<group>"; };
 		A6113A7B2180C87400C6DB5A /* Framework.Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.Base.xcconfig; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 		580B613E215D339600A69E87 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				65E4D8B2225D006300CA7CB3 /* BoxSizeCachingTableView.swift */,
 				580B615E215D40FA00A69E87 /* FocusToolbar.swift */,
 				580B615C215D40E000A69E87 /* InputView.swift */,
 				580B615A215D404500A69E87 /* Accessory.swift */,
@@ -632,6 +635,7 @@
 				580B613A215D2F6800A69E87 /* Image.swift in Sources */,
 				580B612F215D2F6800A69E87 /* Toggle.swift in Sources */,
 				580B612E215D2F6800A69E87 /* Component.swift in Sources */,
+				65E4D8B3225D006300CA7CB3 /* BoxSizeCachingTableView.swift in Sources */,
 				580B614A215D353B00A69E87 /* InputNodes.swift in Sources */,
 				B5BD11C6219301D500DC6A51 /* Search.swift in Sources */,
 				65020C3022030CB000DC8F42 /* InteractionBehavior.swift in Sources */,

--- a/BentoKit/BentoKit/Components/EmptySpace.swift
+++ b/BentoKit/BentoKit/Components/EmptySpace.swift
@@ -12,8 +12,9 @@ extension Component {
             self.styleSheet = styleSheet
         }
 
-        public func render(in view: BaseView) {
+        public func render(in view: View) {
             styleSheet.apply(to: view)
+            view.heightConstraint.constant = height
         }
 
         public func estimatedHeight(forWidth width: CGFloat, inheritedMargins: UIEdgeInsets) -> CGFloat {
@@ -23,5 +24,11 @@ extension Component {
         public func height(forWidth width: CGFloat, inheritedMargins: UIEdgeInsets) -> CGFloat {
             return max(height, 1.1)
         }
+    }
+}
+
+extension Component.EmptySpace {
+    public final class View: BaseView {
+        lazy var heightConstraint: NSLayoutConstraint = self.heightAnchor.constraint(equalToConstant: 0).activated()
     }
 }

--- a/BentoKit/BentoKit/Views/BoxSizeCachingTableView.swift
+++ b/BentoKit/BentoKit/Views/BoxSizeCachingTableView.swift
@@ -1,0 +1,243 @@
+import UIKit
+import ReactiveSwift
+import Bento
+
+open class BoxSizeCachingTableView: SizeCachingTableView {
+    public typealias Layout = BentoTableView.Layout
+
+    public var formStyle: Layout = .topYAligned {
+        didSet {
+            if formStyle != oldValue {
+                setNeedsLayout()
+            }
+        }
+    }
+
+    public var preferredContentHeight: CGFloat = 0.0 {
+        didSet {
+            if preferredContentHeight != oldValue {
+                setNeedsLayout()
+            }
+        }
+    }
+
+    public var additionalContentInsets: UIEdgeInsets = .zero {
+        didSet {
+            if additionalContentInsets != oldValue {
+                setNeedsLayout()
+                deltaForUpdatingContentOffset = CGPoint(x: additionalContentInsets.left,
+                                                        y: additionalContentInsets.top)
+            }
+        }
+    }
+
+    public var keyboardFrame: CGRect = .zero {
+        didSet {
+            if keyboardFrame != oldValue {
+                setNeedsLayout()
+            }
+        }
+    }
+
+    private let fadeOut = UIViewPropertyAnimator(duration: 0.15, curve: .easeInOut, animations: nil)
+    private let fadeIn = UIViewPropertyAnimator(duration: 0.15, curve: .easeInOut, animations: nil)
+
+    private var isTransitioning: Bool = false
+    private var transitionTargetStyle: Layout!
+    private var transitionDidComplete: ((_ willReload: Bool) -> Void)? = nil
+    private var transitionRemoveAll: (() -> Void)? = nil
+
+    private var deltaForUpdatingContentOffset: CGPoint?
+
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        updateScrollViewParameters()
+    }
+
+    /// Transition the form table view to the specified style.
+    ///
+    /// If multiple transition attempts are raised during an on-going fade-out
+    /// animation, only the style and the completion callback of the last
+    /// attempt would be honoured.
+    ///
+    /// The completion callback would be invoked immediately if no transition
+    /// needs to be performed.
+    ///
+    /// The data source and its batch updating logic must react properly to
+    /// `removeAll` callback, which is invoked by the
+    /// `FormTableView` to purge all existing items as part of the form style
+    /// transition.
+    ///
+    /// The table view might inform the completion callback with an asserted
+    /// flag of its intent to reload afterwards. The callback is advised to
+    /// update the data source and avoid calling any UITableView method.
+    ///
+    /// - parameters:
+    ///   - style: The target form style.
+    ///   - completion: The completion callback to invoke when the target form
+    ///                 style has been applied.
+    public func transition(to style: Layout, removeAll: @escaping (() -> Void), completion: @escaping (_ willReload: Bool) -> Void) {
+        let oldStyle = self.formStyle
+
+        if style.shouldFade(from: oldStyle) == false && isTransitioning == false {
+            completion(false)
+            return
+        }
+
+        transitionTargetStyle = style
+        transitionDidComplete = completion
+        transitionRemoveAll = removeAll
+
+        if isTransitioning == false {
+            isTransitioning = true
+
+            // Quickly fade out the UITableView to prepare for a form style change.
+            fadeOut.addAnimations { self.alpha = 0.0 }
+
+            fadeOut.addCompletion { _ in
+                // Clear the table view content immediately.
+                self.transitionRemoveAll?()
+                self.reloadData()
+                self.layoutIfNeeded()
+
+                // The form style should only be updated after the table view
+                // has faded out.
+                self.formStyle = self.transitionTargetStyle
+
+                if self.formStyle.shouldFade(from: oldStyle) || self.isEmpty {
+                    // Inform the callback to update the data source without
+                    // triggering any animation.
+                    self.transitionDidComplete?(true)
+                    self.transitionDidComplete = nil
+                    self.transitionRemoveAll = nil
+
+                    self.contentInset = .zero
+
+                    self.reloadData()
+                    self.layoutIfNeeded()
+                    self.updateScrollViewParameters()
+
+                    if #available(iOS 11, *) {
+                        // The content offset is auto-adjusted correctly under iOS 11.
+                    } else {
+                        self.contentOffset = CGPoint(x: 0, y: -self.contentInset.top)
+                    }
+
+                    // Fade in the UITableView.
+                    self.fadeIn.addAnimations { self.alpha = 1.0 }
+                    self.fadeIn.addCompletion { _ in
+                        self.markTransitionAsCompleted()
+                    }
+                    self.fadeIn.startAnimation()
+                } else {
+                    self.alpha = 1.0
+                    self.contentInset = .zero
+
+                    // Hand over an empty UITableView to the callback.
+                    self.transitionDidComplete?(false)
+                    self.transitionDidComplete = nil
+                    self.transitionRemoveAll = nil
+
+                    self.markTransitionAsCompleted()
+                }
+            }
+
+            fadeOut.startAnimation()
+        }
+    }
+
+    public func deleteRowForSwipeAction(
+        at indexPath: IndexPath,
+        contextCompletion: ((Bool) -> Void)? = nil,
+        completion: @escaping () -> Void
+        ) {
+        precondition(isTransitioning == false)
+        isTransitioning = true
+
+        CATransaction.begin()
+        CATransaction.setCompletionBlock {
+            self.markTransitionAsCompleted()
+            completion()
+        }
+
+        deleteRows(at: [indexPath], with: .automatic)
+        contextCompletion?(true)
+
+        CATransaction.commit()
+    }
+
+    private func markTransitionAsCompleted() {
+        isTransitioning = false
+
+        // Start a transition if a transition attempt is
+        // recorded during the fading in animation.
+        if let style = transitionTargetStyle,
+            let completion = transitionDidComplete,
+            let removeAll = transitionRemoveAll {
+            transition(to: style, removeAll: removeAll, completion: completion)
+        }
+    }
+
+    private func updateScrollViewParameters() {
+        let topInset: CGFloat
+        let viewFrame = convert(bounds, to: nil)
+        let boundedKeyboardHeight = viewFrame.intersection(keyboardFrame).height
+
+        switch formStyle {
+        case .topYAligned, .topYAlignedAlwaysFading:
+            topInset = additionalContentInsets.top
+        case .centerYAligned, .centerYAlignedMinimumFading:
+            topInset = max((preferredContentHeight - contentSize.height - boundedKeyboardHeight) * 0.5, 0.0) + additionalContentInsets.top
+        }
+
+        // `topInset` must be rounded to ensure pixel perfectness and prevent
+        // jittering due to pixel misalignment.
+        let proposedContentInset = UIEdgeInsets(top: topInset.rounded(),
+                                                left: additionalContentInsets.left,
+                                                bottom: max(additionalContentInsets.bottom, boundedKeyboardHeight),
+                                                right: additionalContentInsets.right)
+
+        if proposedContentInset != contentInset {
+            contentInset = proposedContentInset
+            scrollIndicatorInsets = proposedContentInset
+        }
+
+        if let delta = deltaForUpdatingContentOffset {
+            deltaForUpdatingContentOffset = nil
+            contentOffset = CGPoint(x: -delta.x, y: -delta.y)
+        }
+    }
+}
+
+extension BoxSizeCachingTableView: MultilineTextInputAware {
+    @objc public func multilineTextInputHeightDidChange(_ sender: Any) {
+        UIView.setAnimationsEnabled(false)
+        beginUpdates()
+        endUpdates()
+        UIView.setAnimationsEnabled(true)
+
+        func searchCellContainer(of view: UIView) -> UITableViewCell? {
+            if let cell = view as? UITableViewCell {
+                return cell
+            }
+            return view.superview.flatMap(searchCellContainer)
+        }
+
+        guard let view = sender as? UIView,
+            view.isDescendant(of: self),
+            let containingCell = searchCellContainer(of: view),
+            let indexPath = indexPath(for: containingCell)
+            else { return }
+
+        self.scrollToRow(at: indexPath, at: .bottom, animated: false)
+    }
+}
+
+extension BoxSizeCachingTableView {
+    fileprivate var isEmpty: Bool {
+        // Bento may have zero section. Forms have always one section, but the
+        // section may contain zero row.
+        return numberOfSections == 0
+            || numberOfSections == 1 && numberOfRows(inSection: 0) == 0
+    }
+}


### PR DESCRIPTION
As per the implementation plan for size caching in #80, this is the third step.

It makes `BoxViewController` use the newly introduced `SizeCachingTableView` for all of its table views, so that everything gets size cached by default.

`HeightCustomizing` is still applicable since the adapter used by `BoxViewController` falls back to the default adapter behavior only when the `HeightCustomizing` conformance is absence. In any case, it is bound to be removed in the next PR, which is going to be the rebased #121.

P.S. We have to duplicate `BentoTableView` to `BoxSizeCachingTableView`, since otherwise all Forms screens would be broken due to instantiation requirement changes.