### PR TITLE
Propagate `ViewLifecycleAware` calls to the entire view hierarchy.

### DIFF
--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -27,14 +27,20 @@ extension BentoReusableView {
         component?
             .cast(to: ComponentLifecycleAware.self)?
             .willDisplayItem()
-        (containedView as? ViewLifecycleAware)?.willDisplayView()
+
+        containedView?.enumerateAllViews { view in
+            (view as? ViewLifecycleAware)?.willDisplayView()
+        }
     }
 
     func didEndDisplayingView() {
         component?
             .cast(to: ComponentLifecycleAware.self)?
             .didEndDisplayingItem()
-        (containedView as? ViewLifecycleAware)?.didEndDisplayingView()
+
+        containedView?.enumerateAllViews { view in
+            (view as? ViewLifecycleAware)?.didEndDisplayingView()
+        }
     }
 }
 
@@ -63,6 +69,16 @@ extension BentoReusableView where Self: UIView {
             if let new = new {
                 add(new)
             }
+        }
+    }
+}
+
+fileprivate extension UIView {
+    func enumerateAllViews(_ action: (UIView) -> Void) {
+        action(self)
+
+        for view in subviews {
+            view.enumerateAllViews(action)
         }
     }
 }

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -28,7 +28,7 @@ extension BentoReusableView {
             .cast(to: ComponentLifecycleAware.self)?
             .willDisplayItem()
 
-        containedView?.enumerateAllViews { view in
+        containedView?.enumerateAllViewsAndSelf { view in
             (view as? ViewLifecycleAware)?.willDisplayView()
         }
     }
@@ -38,7 +38,7 @@ extension BentoReusableView {
             .cast(to: ComponentLifecycleAware.self)?
             .didEndDisplayingItem()
 
-        containedView?.enumerateAllViews { view in
+        containedView?.enumerateAllViewsAndSelf { view in
             (view as? ViewLifecycleAware)?.didEndDisplayingView()
         }
     }
@@ -74,11 +74,11 @@ extension BentoReusableView where Self: UIView {
 }
 
 fileprivate extension UIView {
-    func enumerateAllViews(_ action: (UIView) -> Void) {
+    func enumerateAllViewsAndSelf(_ action: (UIView) -> Void) {
         action(self)
 
         for view in subviews {
-            view.enumerateAllViews(action)
+            view.enumerateAllViewsAndSelf(action)
         }
     }
 }


### PR DESCRIPTION
... so that all views can reliably get notified of the visibility of the component. 