### PR TITLE
Add separator height when using cached row size.

### DIFF
--- a/Bento/Adapters/TableViewAdapter.swift
+++ b/Bento/Adapters/TableViewAdapter.swift
@@ -97,7 +97,7 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
 
     @objc(tableView:heightForRowAtIndexPath:)
     open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return store.size(forItemAt: indexPath)?.height
+        return store.size(forItemAt: indexPath).map { $0.height + tableView.separatorHeight }
             ?? tableView.rowHeight
     }
 
@@ -125,7 +125,7 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
 
     @objc(tableView:estimatedHeightForRowAtIndexPath:)
     open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return store.size(forItemAt: indexPath)?.height
+        return store.size(forItemAt: indexPath).map { $0.height + tableView.separatorHeight }
             ?? tableView.estimatedRowHeight
     }
 
@@ -251,3 +251,9 @@ internal final class BentoTableViewAdapter<SectionID: Hashable, ItemID: Hashable
       UITableViewDataSource,
       UITableViewDelegate
 {}
+
+extension UITableView {
+    fileprivate var separatorHeight: CGFloat {
+        return separatorStyle != .none ? 1.0 / contentScaleFactor : 0.0
+    }
+}

--- a/BentoKit/BentoKitTests/SnapshotTests/Screen/BoxViewControllerSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Screen/BoxViewControllerSnapshotTests.swift
@@ -11,6 +11,18 @@ final class BoxViewControllerSnapshotTests: SnapshotTestCase {
         self.recordMode = false
     }
 
+    func test_separatorsEnabled() {
+        Device.all.forEach {
+            let vm = ViewModel(state: .text("String Title"))
+            let vc = BoxViewController(viewModel: vm,
+                                       renderer: EmptySpaceRenderer.self,
+                                       rendererConfig: (),
+                                       appearance: Property(value: TestAppearance()))
+            let nc = UINavigationController(rootViewController: vc)
+            verify(viewController: nc, for: $0)
+        }
+    }
+
     func testWithYCenterAligned_StringTitle() {
         Device.all.forEach {
             let vm = ViewModel(state: .text("String Title"))
@@ -97,6 +109,64 @@ final class BoxViewControllerSnapshotTests: SnapshotTestCase {
                             height: 30,
                             styleSheet: ViewStyleSheet<UIView>()
                                 .compose(\.backgroundColor, .blue)
+                        )
+                    )
+            )
+        }
+    }
+
+    struct EmptySpaceRenderer: BoxRenderer {
+        typealias State = NavigationTitleItem
+        typealias Action = Never
+        typealias SectionId = Int
+        typealias RowId = Int
+
+        private let observer: Sink<Action>
+
+        var configuration: BoxConfiguration {
+            return BoxConfiguration(shouldUseSystemSeparators: true)
+        }
+
+        var styleSheet: ViewStyleSheet<UIView> {
+            return ViewStyleSheet(backgroundColor: .white)
+        }
+
+        init(observer: @escaping Sink<Action>, appearance: TestAppearance, config: EmptyConfig) {
+            self.observer = observer
+        }
+
+        func render(state: NavigationTitleItem) -> Screen<SectionId, RowId> {
+            return Screen(
+                titleItem: state,
+                formStyle: .topYAligned,
+                box: .empty
+                    |-+ Section(id: 0)
+                    |---+ Node(id: 0, component:
+                        Component.EmptySpace(
+                            height: 30,
+                            styleSheet: ViewStyleSheet<UIView>()
+                                .compose(\.backgroundColor, UIColor.blue.withAlphaComponent(0.05))
+                        )
+                    )
+                    |---+ Node(id: 1, component:
+                        Component.EmptySpace(
+                            height: 30,
+                            styleSheet: ViewStyleSheet<UIView>()
+                                .compose(\.backgroundColor, UIColor.red.withAlphaComponent(0.05))
+                        )
+                    )
+                    |---+ Node(id: 2, component:
+                        Component.EmptySpace(
+                            height: 30,
+                            styleSheet: ViewStyleSheet<UIView>()
+                                .compose(\.backgroundColor, UIColor.blue.withAlphaComponent(0.05))
+                        )
+                    )
+                    |---+ Node(id: 3, component:
+                        Component.EmptySpace(
+                            height: 30,
+                            styleSheet: ViewStyleSheet<UIView>()
+                                .compose(\.backgroundColor, UIColor.red.withAlphaComponent(0.05))
                         )
                     )
             )

--- a/BentoKit/BentoKitTests/SnapshotTests/Screen/BoxViewControllerSnapshotTests.swift
+++ b/BentoKit/BentoKitTests/SnapshotTests/Screen/BoxViewControllerSnapshotTests.swift
@@ -19,7 +19,7 @@ final class BoxViewControllerSnapshotTests: SnapshotTestCase {
                                        rendererConfig: (),
                                        appearance: Property(value: TestAppearance()))
             let nc = UINavigationController(rootViewController: vc)
-            verify(viewController: nc, for: $0)
+            verify(viewController: UINavigationController(rootViewController: vc), for: $0)
         }
     }
 

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/test_separatorsEnabled_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/test_separatorsEnabled_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ecf8fce2e51aacdb7d4af6a4192a2bac253364ddac987e4a015caeddab97d35
+size 25565

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/test_separatorsEnabled_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/test_separatorsEnabled_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6641fa151a5f185354288b39d310406978858e1ca572f565334d87addc58f307
+size 29447

--- a/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/test_separatorsEnabled_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoKitTests.BoxViewControllerSnapshotTests/test_separatorsEnabled_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:490b3048d67dea7ac9457efe538769d7fa9d74d13cb2dd05e00f7631860159e1
+size 30063


### PR DESCRIPTION
Part of https://babylonpartners.atlassian.net/browse/CNSMR-1333

Copy pasta from BoxTableViewAdapter. It is necessary since UITableViewCell would otherwise take space from the content view, causing the component not having enough space for its content. :(