### PR TITLE
Remove workarounds that are superseded by `PreSizingLayoutPassRequiring`.

### DIFF
--- a/BentoKit/BentoKit/Screen/BoxViewController.swift
+++ b/BentoKit/BentoKit/Screen/BoxViewController.swift
@@ -330,22 +330,11 @@ open class BoxViewController<ViewModel: BoxViewModel, Renderer: BoxRenderer, App
                 self.tableView.render(mainBox, animated: willReload.isFalse)
                 self.topTableView.render(self.topBox, animated: willReload.isFalse)
                 self.bottomTableView.render(self.bottomBox, animated: willReload.isFalse)
-                // Trigger a second layout pass so as to let complex components
-                // with ambiguous height to be sized correctly.
-                self.tableView.beginUpdates()
-                self.tableView.endUpdates()
             }
         } else {
             tableView.formStyle = screen.formStyle
             tableView.render(mainBox, animated: false)
             tableView.layoutIfNeeded()
-
-            UIView.performWithoutAnimation {
-                // Trigger a second layout pass so as to let complex components
-                // with ambiguous height to be sized correctly.
-                self.tableView.beginUpdates()
-                self.tableView.endUpdates()
-            }
 
             topTableView.render(topBox, animated: false)
             bottomTableView.render(bottomBox, animated: false)


### PR DESCRIPTION
These workarounds were introduced to mitigate the height computation issues of vertically stacked multiline labels. Now that we have introduced the formal mechanism to address this class of issues, i.e. `PreSizingLayoutPassRequiring`, we should now remove them.

Completes #151.