### PR TITLE
Improve performance of estimated height queries.

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		65496FB8211C323F00511D8A /* TableViewContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587F0717201B355800ACD219 /* TableViewContainerCell.swift */; };
 		65496FB9211C323F00511D8A /* TableViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9509BC2762C8B4277B973D8 /* TableViewAdapter.swift */; };
 		65570424222E88A500EEE8EC /* RequiringPreSizingLayoutPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65570423222E88A500EEE8EC /* RequiringPreSizingLayoutPass.swift */; };
+		65836F8322706F030043F587 /* AdapterStoreItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65836F8222706F030043F587 /* AdapterStoreItemTests.swift */; };
 		65A69EDF218B8892005D90AC /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A69EDE218B8891005D90AC /* UICollectionViewExtensions.swift */; };
 		65A69EE1218B8AB6005D90AC /* CustomCollectionViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A69EE0218B8AB6005D90AC /* CustomCollectionViewAdapter.swift */; };
 		65BA922E20AF388F004AEF18 /* UITableViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BA922D20AF388F004AEF18 /* UITableViewExtensions.swift */; };
@@ -269,6 +270,7 @@
 		651E75BF221005E300130866 /* UIKitContainerDiffApplicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitContainerDiffApplicationTests.swift; sourceTree = "<group>"; };
 		653D460A2256665000CF3E4C /* AdapterStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdapterStoreTests.swift; sourceTree = "<group>"; };
 		65570423222E88A500EEE8EC /* RequiringPreSizingLayoutPass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiringPreSizingLayoutPass.swift; sourceTree = "<group>"; };
+		65836F8222706F030043F587 /* AdapterStoreItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdapterStoreItemTests.swift; sourceTree = "<group>"; };
 		65A69EDE218B8891005D90AC /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensions.swift; sourceTree = "<group>"; };
 		65A69EE0218B8AB6005D90AC /* CustomCollectionViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionViewAdapter.swift; sourceTree = "<group>"; };
 		65BA922D20AF388F004AEF18 /* UITableViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableViewExtensions.swift; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 			children = (
 				7448E82A2266212B0036B2D6 /* SnapshotTests */,
 				653D460A2256665000CF3E4C /* AdapterStoreTests.swift */,
+				65836F8222706F030043F587 /* AdapterStoreItemTests.swift */,
 				7448E8722266429D0036B2D6 /* StyleSheetTests.swift */,
 				9A3EF77F205D866F00D043AC /* AnyRenderableTests.swift */,
 				740921B520ACDDDA00B59F5C /* IfTests.swift */,
@@ -1138,6 +1141,7 @@
 				58FC4428207CF2BB00DA3614 /* TestId.swift in Sources */,
 				7448E8462266220C0036B2D6 /* EmptySpaceComponentSnapshotTests.swift in Sources */,
 				7448E8732266429D0036B2D6 /* StyleSheetTests.swift in Sources */,
+				65836F8322706F030043F587 /* AdapterStoreItemTests.swift in Sources */,
 				58D27BA721B83B2700DC9600 /* DeletableTests.swift in Sources */,
 				7448E8452266220C0036B2D6 /* ToggleSnapshotTests.swift in Sources */,
 				653D460B2256665000CF3E4C /* AdapterStoreTests.swift in Sources */,

--- a/Bento/Adapters/TableViewAdapter.swift
+++ b/Bento/Adapters/TableViewAdapter.swift
@@ -75,7 +75,7 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
 
     @objc open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         switch store.size(for: .header, inSection: section) {
-        case .cachingDisabled:
+        case .noCachedResult:
             return tableView.sectionHeaderHeight
         case .doesNotExist:
             return .leastNonzeroMagnitude
@@ -86,7 +86,7 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
 
     @objc open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         switch store.size(for: .footer, inSection: section) {
-        case .cachingDisabled:
+        case .noCachedResult:
             return tableView.sectionFooterHeight
         case .doesNotExist:
             return .leastNonzeroMagnitude
@@ -102,8 +102,8 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
     }
 
     @objc open func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        switch store.size(for: .header, inSection: section) {
-        case .cachingDisabled:
+        switch store.size(for: .header, inSection: section, allowEstimation: true) {
+        case .noCachedResult:
             return tableView.estimatedSectionHeaderHeight
         case .doesNotExist:
             return .leastNonzeroMagnitude
@@ -113,8 +113,8 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
     }
 
     @objc open func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        switch store.size(for: .footer, inSection: section) {
-        case .cachingDisabled:
+        switch store.size(for: .footer, inSection: section, allowEstimation: true) {
+        case .noCachedResult:
             return tableView.estimatedSectionFooterHeight
         case .doesNotExist:
             return .leastNonzeroMagnitude
@@ -125,7 +125,8 @@ open class TableViewAdapterBase<SectionID: Hashable, ItemID: Hashable>
 
     @objc(tableView:estimatedHeightForRowAtIndexPath:)
     open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return store.size(forItemAt: indexPath).map { $0.height + tableView.separatorHeight }
+        return store.size(forItemAt: indexPath, allowEstimation: true)
+            .map { $0.height + tableView.separatorHeight }
             ?? tableView.estimatedRowHeight
     }
 

--- a/BentoTests/AdapterStoreItemTests.swift
+++ b/BentoTests/AdapterStoreItemTests.swift
@@ -1,0 +1,23 @@
+@testable import Bento
+import Nimble
+import XCTest
+import FlexibleDiff
+
+private let size = CGSize(width: 100, height: 100)
+
+class AdapterStoreItemTests: XCTestCase {
+    func test_sized() {
+        expect(Item.sized(size).size(allowEstimation: true)) == size
+        expect(Item.sized(size).size(allowEstimation: false)) == size
+    }
+
+    func test_invalidated_with_old_size() {
+        expect(Item.invalidated(size).size(allowEstimation: true)) == size
+        expect(Item.invalidated(size).size(allowEstimation: false)).to(beNil())
+    }
+
+    func test_invalidated_with_no_size() {
+        expect(Item.invalidated(nil).size(allowEstimation: true)).to(beNil())
+        expect(Item.invalidated(nil).size(allowEstimation: false)).to(beNil())
+    }
+}


### PR DESCRIPTION
`SizeCachingTableView` currently answers all estimated height queries with the final size of the component. This causes significant performance toll when initialising screens with large amount of items.

This PR changes it to respond with a quick estimation, which can be

* the last known (but invalidated) height of the ID path; or in its absence
* the estimated height as defined by the `SizeCachingTableView`.