### PR TITLE
Make `ComponentLifecycleAware` public.

### DIFF
--- a/Bento/Renderable/ComponentLifecycleAware.swift
+++ b/Bento/Renderable/ComponentLifecycleAware.swift
@@ -1,4 +1,4 @@
-protocol ComponentLifecycleAware {
+public protocol ComponentLifecycleAware {
     func willDisplayItem()
     func didEndDisplayingItem()
 }


### PR DESCRIPTION
Composite components should notify its children about the change in their visibility. Expose the protocol so that composite components outside the Bento framework can implement this.