### PR TITLE
Adds AnyRenderableConvirtable

### DIFF
--- a/Bento/Renderable/AnyRenderable.swift
+++ b/Bento/Renderable/AnyRenderable.swift
@@ -1,5 +1,15 @@
 import UIKit
 
+public protocol AnyRenderableConvertible {
+    func asAnyRenderable() -> AnyRenderable
+}
+
+public extension AnyRenderableConvertible where Self: Renderable {
+    func asAnyRenderable() -> AnyRenderable {
+        return AnyRenderable(self)
+    }
+}
+
 public struct AnyRenderable: Renderable {
     /// The runtime view type of the wrapped `Renderable`.
     public var viewType: NativeView.Type {
@@ -70,6 +80,10 @@ public struct AnyRenderable: Renderable {
 
         return view
     }
+    
+    public func asAnyRenderable() -> AnyRenderable {
+        return self
+    }
 }
 
 class AnyRenderableBox<Base: Renderable>: AnyRenderableBoxBase {
@@ -105,10 +119,13 @@ class AnyRenderableBoxBase {
     var componentType: Any.Type { fatalError() }
 
     init() {}
+    
+    func render(in view: UIView) { fatalError() }
+    func cast<T>(to type: T.Type) -> T? { fatalError() }
+}
 
+extension AnyRenderableBox: AnyRenderableConvertible {
     func asAnyRenderable() -> AnyRenderable {
         return AnyRenderable(self)
     }
-    func render(in view: UIView) { fatalError() }
-    func cast<T>(to type: T.Type) -> T? { fatalError() }
 }

--- a/Bento/Renderable/Renderable.swift
+++ b/Bento/Renderable/Renderable.swift
@@ -2,17 +2,13 @@ import UIKit
 
 /// Protocol which every Component needs to conform to.
 /// - View: UIView subtype which is the top level view type of the component.
-public protocol Renderable {
+public protocol Renderable: AnyRenderableConvertible {
     associatedtype View: NativeView
 
     func render(in view: View)
 }
 
 public extension Renderable {
-    func asAnyRenderable() -> AnyRenderable {
-        return AnyRenderable(self)
-    }
-
     func deletable(
         deleteActionText: String,
         backgroundColor: UIColor? = nil,


### PR DESCRIPTION
I'd like to add `AnyRenderableConvirtable` into Bento.

## Why?
In our main project, we need to have an array of `AnyRenderable` to be able to call `.stack(...)` method. Because of that, every element of the array has to have `.asAnyRenderable()` called at the end of its declaration. I'm just too lazy to do so every time.

With `AnyRenderableConvirtable` the `Stack` component can be responsible to call `asAnyRenderable()` on it's children :)  

```
extension Array where Element == Optional<AnyRenderableConvirtable> { ... }
```