### PR TITLE
Fix rendering issue with `PreSizingLayoutPassRequiring`

### DIFF
--- a/Bento/Views/RequiringPreSizingLayoutPass.swift
+++ b/Bento/Views/RequiringPreSizingLayoutPass.swift
@@ -37,6 +37,12 @@ extension UIView {
 
     func triggerPresizingLayoutPassIfNeeded(forTargetSize size: CGSize) {
         if needsPresizingLayoutPass {
+            // NOTE: the target size passed in always has a height of zero
+            // when called from `systemLayoutSizeFitting(_ targetSize: CGSize)`
+            // All we care about is the width. Setting the height to zero
+            // would make the cell render with zero height first then animate
+            // up to the correct height on every render pass.
+            // `layoutIfNeeded()` will take of setting the correct height.
             bounds.size.width = size.width
             layoutIfNeeded()
         }

--- a/Bento/Views/RequiringPreSizingLayoutPass.swift
+++ b/Bento/Views/RequiringPreSizingLayoutPass.swift
@@ -37,7 +37,7 @@ extension UIView {
 
     func triggerPresizingLayoutPassIfNeeded(forTargetSize size: CGSize) {
         if needsPresizingLayoutPass {
-            bounds.size = size
+            bounds.size.width = size.width
             layoutIfNeeded()
         }
     }


### PR DESCRIPTION
Only set the `bounds.size.width` from the target size, which is all that is needed to calculate the cell height. Fixes #170

Setting the `bounds.size` (including the `height`) resets the height of the cell leading to the cell being always rendered first with zero height, and then the correct height.