### PR TITLE
[MN-353] Make sure MultilineTextInputAware invalidates the size cache as appropriate.

### DIFF
--- a/Bento/Adapters/AdapterProtocol.swift
+++ b/Bento/Adapters/AdapterProtocol.swift
@@ -3,6 +3,7 @@ internal protocol AdapterStoreAccessible: AnyObject {
     var layoutMargins: UIEdgeInsets { get set }
     var boundSize: CGSize { get set }
     var cachesSizeInformation: Bool { get set }
+    func invalidateSize(at indexPath: IndexPath)
 }
 
 /// Provide a default implementation for all adapter store owners.
@@ -27,5 +28,9 @@ extension AdapterStoreOwner {
     var cachesSizeInformation: Bool {
         get { return store.cachesSizeInformation }
         set { store.cachesSizeInformation = newValue }
+    }
+
+    func invalidateSize(at indexPath: IndexPath) {
+        store.invalidateSize(at: indexPath)
     }
 }

--- a/Bento/Adapters/AdapterStore.swift
+++ b/Bento/Adapters/AdapterStore.swift
@@ -135,6 +135,10 @@ struct AdapterStore<SectionID: Hashable, ItemID: Hashable> {
         }
     }
 
+    mutating func invalidateSize(at indexPath: IndexPath) {
+        info[indexPath.section].items[indexPath.row].invalidate()
+    }
+
     mutating func resetCachedInfo() {
         info = Array(repeating: SectionInfo(), count: sections.count)
         for index in info.indices {

--- a/Bento/Views/BentoTableView.swift
+++ b/Bento/Views/BentoTableView.swift
@@ -207,11 +207,6 @@ open class BentoTableView: UITableView {
 
 extension BentoTableView: MultilineTextInputAware {
     @objc public func multilineTextInputHeightDidChange(_ sender: Any) {
-        UIView.setAnimationsEnabled(false)
-        beginUpdates()
-        endUpdates()
-        UIView.setAnimationsEnabled(true)
-
         func searchCellContainer(of view: UIView) -> UITableViewCell? {
             if let cell = view as? UITableViewCell {
                 return cell
@@ -224,6 +219,12 @@ extension BentoTableView: MultilineTextInputAware {
             let containingCell = searchCellContainer(of: view),
             let indexPath = indexPath(for: containingCell)
             else { return }
+
+        UIView.setAnimationsEnabled(false)
+        beginUpdates()
+        adapterStore.invalidateSize(at: indexPath)
+        endUpdates()
+        UIView.setAnimationsEnabled(true)
 
         self.scrollToRow(at: indexPath, at: .bottom, animated: false)
     }

--- a/BentoTests/AdapterStoreTests.swift
+++ b/BentoTests/AdapterStoreTests.swift
@@ -191,6 +191,28 @@ class AdapterStoreTests: XCTestCase {
         expect(store.size(forItemAt: [0, 0])) == CGSize(width: 1, height: 5000)
     }
 
+    func test_should_invalidate_cached_size() {
+        var store = TestStore()
+        store.cachesSizeInformation = true
+        store.boundSize = defaultBoundSize
+
+        let component = TestComponent(size: CGSize(width: 5000, height: 5000))
+
+        store.update(
+            with: [
+                Section(id: 0, items: [Node(id: 0, component: component)])
+            ],
+            knownSupplements: []
+        )
+
+        expect(store.size(forItemAt: [0, 0])) == CGSize(width: 5000, height: 5000)
+
+        component.size = CGSize(width: 1000, height: 1000)
+        store.invalidateSize(at: [0, 0])
+        expect(store.size(forItemAt: [0, 0], allowEstimation: true)) == CGSize(width: 5000, height: 5000)
+        expect(store.size(forItemAt: [0, 0])) == CGSize(width: 1000, height: 1000)
+    }
+
     private func makeSingleSectionWithSingleItem(value: CGFloat) -> [Section<Int, Int>] {
         return [
             Section(
@@ -449,8 +471,8 @@ struct NoSizePlaceholder: Renderable {
     func render(in view: UIView) {}
 }
 
-struct TestComponent: Renderable {
-    let size: CGSize
+final class TestComponent: Renderable {
+    var size: CGSize
 
     init(size: CGSize) {
         self.size = size


### PR DESCRIPTION
https://babylonpartners.atlassian.net/browse/MN-353

The MultilineTextInput component is not expanding as the user types at the moment, due to it not currently invalidating the UITableView size cache when it receives the `multilineTextInputHeightDidChange` call.