### PR TITLE
[MN-353] Make sure MultilineTextInputAware invalidates the size cache as appropriate in BentoKit.

### DIFF
--- a/Bento/Adapters/AdapterProtocol.swift
+++ b/Bento/Adapters/AdapterProtocol.swift
@@ -1,5 +1,9 @@
+public protocol SizeInvalidationSupporting: AnyObject {
+    func invalidateSize(at indexPath: IndexPath)
+}
+
 /// Provide generic parameter agnostic access to the adapter.
-internal protocol AdapterStoreAccessible: AnyObject {
+internal protocol AdapterStoreAccessible: SizeInvalidationSupporting {
     var layoutMargins: UIEdgeInsets { get set }
     var boundSize: CGSize { get set }
     var cachesSizeInformation: Bool { get set }
@@ -30,7 +34,7 @@ extension AdapterStoreOwner {
         set { store.cachesSizeInformation = newValue }
     }
 
-    func invalidateSize(at indexPath: IndexPath) {
+    public func invalidateSize(at indexPath: IndexPath) {
         store.invalidateSize(at: indexPath)
     }
 }

--- a/Bento/Bento/UITableViewExtensions.swift
+++ b/Bento/Bento/UITableViewExtensions.swift
@@ -56,11 +56,15 @@ extension UITableView {
         return getAdapter()
     }
 
-    var adapterStore: AdapterStoreAccessible {
+    internal var adapterStore: AdapterStoreAccessible {
         let adapter = typeErasedAdapter
         precondition(adapter != nil, "You must access the adapter store directly only after the adapter has been configured.")
 
         return typeErasedAdapter as! AdapterStoreAccessible
+    }
+
+    public var sizeInvalidator: SizeInvalidationSupporting {
+        return adapterStore as SizeInvalidationSupporting
     }
 
     var typeErasedAdapter: AnyObject? {

--- a/BentoKit/BentoKit/Views/BoxSizeCachingTableView.swift
+++ b/BentoKit/BentoKit/Views/BoxSizeCachingTableView.swift
@@ -211,11 +211,6 @@ open class BoxSizeCachingTableView: SizeCachingTableView {
 
 extension BoxSizeCachingTableView: MultilineTextInputAware {
     @objc public func multilineTextInputHeightDidChange(_ sender: Any) {
-        UIView.setAnimationsEnabled(false)
-        beginUpdates()
-        endUpdates()
-        UIView.setAnimationsEnabled(true)
-
         func searchCellContainer(of view: UIView) -> UITableViewCell? {
             if let cell = view as? UITableViewCell {
                 return cell
@@ -228,6 +223,12 @@ extension BoxSizeCachingTableView: MultilineTextInputAware {
             let containingCell = searchCellContainer(of: view),
             let indexPath = indexPath(for: containingCell)
             else { return }
+
+        UIView.setAnimationsEnabled(false)
+        beginUpdates()
+        adapterStore.invalidateSize(at: indexPath)
+        endUpdates()
+        UIView.setAnimationsEnabled(true)
 
         self.scrollToRow(at: indexPath, at: .bottom, animated: false)
     }

--- a/BentoKit/BentoKit/Views/BoxSizeCachingTableView.swift
+++ b/BentoKit/BentoKit/Views/BoxSizeCachingTableView.swift
@@ -226,7 +226,7 @@ extension BoxSizeCachingTableView: MultilineTextInputAware {
 
         UIView.setAnimationsEnabled(false)
         beginUpdates()
-        adapterStore.invalidateSize(at: indexPath)
+        sizeInvalidator.invalidateSize(at: indexPath)
         endUpdates()
         UIView.setAnimationsEnabled(true)
 


### PR DESCRIPTION
#172 fixed `BentoTableView` in Bento, but there is also `SizeCachingTableView` in BentoKit.