### PR TITLE
Fix TD's detail label becoming crushed due to a large title

### DIFF
--- a/Bento/Components/DetailedDescription.swift
+++ b/Bento/Components/DetailedDescription.swift
@@ -225,7 +225,7 @@ private extension Component.DetailedDescription.View {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.setContentHuggingPriority(.required, for: .vertical)
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 }

--- a/BentoKit/BentoKit/Components/TitledDescription.swift
+++ b/BentoKit/BentoKit/Components/TitledDescription.swift
@@ -327,7 +327,7 @@ private extension Component.TitledDescription.View {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.setContentHuggingPriority(.required, for: .vertical)
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 }


### PR DESCRIPTION
This PR fixes a bug in which large titles inside a TitledDescription would shrink the detail label up to a point that it would not longer be readable. 

In order to fix this, the content compression resistance priority of the label itself was simply lowered from `defaultHigh` to `defaultLow`.