### PR TITLE
Make `Section.init(id:items:supplements:)` public

### DIFF
--- a/Bento/Bento/Section.swift
+++ b/Bento/Bento/Section.swift
@@ -35,7 +35,7 @@ public struct Section<SectionID: Hashable, ItemID: Hashable> {
                             .footer: AnyRenderable(footer)]
     }
 
-    internal init(id: SectionID, items: [Item], supplements: [Supplement: AnyRenderable]) {
+    public init(id: SectionID, items: [Item], supplements: [Supplement: AnyRenderable]) {
         self.id = id
         self.items = items
         self.supplements = supplements


### PR DESCRIPTION
This PR exposes the most basic initializer to the public so that optional `header` / `footer` can be easily set and filtered.

For example, filtering using `compactMapValues`:

```swift
let section = Section(id: ..., items: ..., supplements: [
    .header: maybeHeader()
    .footer: maybeFooter()
].compactMapValues { $0 })
```

Note that current `init`s are overloaded with taking non-optional `header` / `footer` arguments, which makes hard to set optional value as a filterable type.

Making this initializer public makes sense as long as `public func Section.adding` is also public.

### Alternative consideration

```diff
-    public init<Header: Renderable, Footer: Renderable>(id: SectionID, header: Header, footer: Footer, items: [Item] = []) {
+    public init<Header: Renderable, Footer: Renderable>(id: SectionID, header: Header? = nil, footer: Footer? = nil, items: [Item] = []) {
```

Though above code might work, there may still exist ambiguity with other overloaded `init`s, so I decided not to modify as so.