### PR TITLE
[CNSMR-1713] Custom Input should work with AnyRenderable.

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		65496FB8211C323F00511D8A /* TableViewContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587F0717201B355800ACD219 /* TableViewContainerCell.swift */; };
 		65496FB9211C323F00511D8A /* TableViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9509BC2762C8B4277B973D8 /* TableViewAdapter.swift */; };
 		65570424222E88A500EEE8EC /* RequiringPreSizingLayoutPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65570423222E88A500EEE8EC /* RequiringPreSizingLayoutPass.swift */; };
+		655AF0C8229FE61600611321 /* CustomInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655AF0C7229FE61600611321 /* CustomInputTests.swift */; };
 		65836F8322706F030043F587 /* AdapterStoreItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65836F8222706F030043F587 /* AdapterStoreItemTests.swift */; };
 		65836F932270A9B60043F587 /* CustomInputComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65836F922270A9B60043F587 /* CustomInputComponent.swift */; };
 		65A69EDF218B8892005D90AC /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A69EDE218B8891005D90AC /* UICollectionViewExtensions.swift */; };
@@ -279,6 +280,7 @@
 		651E75BF221005E300130866 /* UIKitContainerDiffApplicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitContainerDiffApplicationTests.swift; sourceTree = "<group>"; };
 		653D460A2256665000CF3E4C /* AdapterStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdapterStoreTests.swift; sourceTree = "<group>"; };
 		65570423222E88A500EEE8EC /* RequiringPreSizingLayoutPass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiringPreSizingLayoutPass.swift; sourceTree = "<group>"; };
+		655AF0C7229FE61600611321 /* CustomInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomInputTests.swift; sourceTree = "<group>"; };
 		65836F8222706F030043F587 /* AdapterStoreItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdapterStoreItemTests.swift; sourceTree = "<group>"; };
 		65836F922270A9B60043F587 /* CustomInputComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomInputComponent.swift; sourceTree = "<group>"; };
 		65A69EDE218B8891005D90AC /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensions.swift; sourceTree = "<group>"; };
@@ -605,6 +607,7 @@
 				9A784702205EB61D00FA597E /* TestId.swift */,
 				58D27BA621B83B2700DC9600 /* DeletableTests.swift */,
 				5830C5E621F22DDC0029044B /* ComponentLifecycleTests.swift */,
+				655AF0C7229FE61600611321 /* CustomInputTests.swift */,
 				651E75BF221005E300130866 /* UIKitContainerDiffApplicationTests.swift */,
 				5B6807932266818F006AA479 /* SizeCachingTableViewTests.swift */,
 				58FC4421207CF29F00DA3614 /* Info.plist */,
@@ -1171,6 +1174,7 @@
 				65836F8322706F030043F587 /* AdapterStoreItemTests.swift in Sources */,
 				58D27BA721B83B2700DC9600 /* DeletableTests.swift in Sources */,
 				7448E8452266220C0036B2D6 /* ToggleSnapshotTests.swift in Sources */,
+				655AF0C8229FE61600611321 /* CustomInputTests.swift in Sources */,
 				653D460B2256665000CF3E4C /* AdapterStoreTests.swift in Sources */,
 				7448E8482266220C0036B2D6 /* ActivityComponentSnapshotTests.swift in Sources */,
 				58FC4429207CF2BB00DA3614 /* TestRenderable.swift in Sources */,

--- a/Bento/Renderable/ViewStorage.swift
+++ b/Bento/Renderable/ViewStorage.swift
@@ -1,8 +1,8 @@
 public struct ViewStorage {
     internal let componentType: Any.Type
-    internal let view: ViewStorageOwner
+    internal let view: BentoReusableView
 
-    internal init(componentType: Any.Type, view: ViewStorageOwner) {
+    internal init(componentType: Any.Type, view: BentoReusableView) {
         self.componentType = componentType
         self.view = view
     }

--- a/Bento/Renderable/ViewStorage.swift
+++ b/Bento/Renderable/ViewStorage.swift
@@ -1,8 +1,8 @@
 public struct ViewStorage {
     internal let componentType: Any.Type
-    internal let view: BentoReusableView
+    internal let view: ViewStorageOwner
 
-    internal init(componentType: Any.Type, view: BentoReusableView) {
+    internal init(componentType: Any.Type, view: ViewStorageOwner) {
         self.componentType = componentType
         self.view = view
     }

--- a/Bento/Views/BentoReusableView.swift
+++ b/Bento/Views/BentoReusableView.swift
@@ -1,20 +1,23 @@
-protocol BentoReusableView: NativeView {
-    var containedView: NativeView? { get set }
-    var contentView: NativeView { get }
-    var component: AnyRenderable? { get set }
+public protocol ViewStorageOwner: NativeView {
     var storage: [StorageKey: Any] { get set }
 }
 
-struct StorageKey: Hashable {
+protocol BentoReusableView: ViewStorageOwner {
+    var containedView: NativeView? { get set }
+    var contentView: NativeView { get }
+    var component: AnyRenderable? { get set }
+}
+
+public struct StorageKey: Hashable {
     let component: Any.Type
     let identifier: ObjectIdentifier
 
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(component))
         hasher.combine(identifier)
     }
 
-    static func == (lhs: StorageKey, rhs: StorageKey) -> Bool {
+    public static func == (lhs: StorageKey, rhs: StorageKey) -> Bool {
         return lhs.component == rhs.component && lhs.identifier == rhs.identifier
     }
 }

--- a/Bento/Views/CollectionViewContainerCell.swift
+++ b/Bento/Views/CollectionViewContainerCell.swift
@@ -9,6 +9,7 @@ final class CollectionViewContainerCell: UICollectionViewCell {
 
     var component: AnyRenderable?
     var storage: [StorageKey : Any] = [:]
+    var isDisplaying: Bool = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Bento/Views/CollectionViewContainerReusableView.swift
+++ b/Bento/Views/CollectionViewContainerReusableView.swift
@@ -13,6 +13,7 @@ final class CollectionViewContainerReusableView: UICollectionReusableView {
 
     var component: AnyRenderable?
     var storage: [StorageKey : Any] = [:]
+    var isDisplaying: Bool = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Bento/Views/TableViewContainerCell.swift
+++ b/Bento/Views/TableViewContainerCell.swift
@@ -9,6 +9,7 @@ final class TableViewContainerCell: UITableViewCell {
 
     var component: AnyRenderable?
     var storage: [StorageKey : Any] = [:]
+    var isDisplaying: Bool = false
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)

--- a/Bento/Views/TableViewHeaderFooterView.swift
+++ b/Bento/Views/TableViewHeaderFooterView.swift
@@ -9,6 +9,7 @@ final class TableViewHeaderFooterView: UITableViewHeaderFooterView {
 
     var component: AnyRenderable?
     var storage: [StorageKey : Any] = [:]
+    var isDisplaying: Bool = false
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)

--- a/BentoTests/CustomInputTests.swift
+++ b/BentoTests/CustomInputTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import UIKit
+import Nimble
+@testable import Bento
+
+final class CustomInputTests: XCTestCase {
+    func test_customInput_shouldDecorateAnyRenderable() {
+        let tableView = UITableView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
+
+        tableView.render(
+            Box.empty
+                |-+ Section(id: 0)
+                |---+ Node(id: 0, component:
+                    A().asAnyRenderable()
+                        .customInput(Node<Int>(id: 0, component: DummyComponent()))
+            )
+        )
+
+        tableView.setNeedsLayout()
+        tableView.layoutIfNeeded()
+
+        XCTAssertNotNil(tableView.cellForRow(at: [0, 0]))
+
+        tableView.render(
+            Box.empty
+                |-+ Section(id: 0)
+                |---+ Node(id: 0, component:
+                    B().asAnyRenderable()
+                        .customInput(Node<Int>(id: 0, component: DummyComponent()))
+            )
+        )
+
+        tableView.setNeedsLayout()
+        tableView.layoutIfNeeded()
+
+        XCTAssertNotNil(tableView.cellForRow(at: [0, 0]))
+    }
+}
+
+private struct A: Renderable {
+    func render(in view: UILabel) {}
+}
+
+private struct B: Renderable {
+    func render(in view: UIButton) {}
+}


### PR DESCRIPTION
https://babylonpartners.atlassian.net/browse/CNSMR-1713

Bento Custom Input operator should work when decorating the type-erased AnyRenderable. This is currently crashing since statically speaking `AnyRenderable.View` is not the same as its wrapping value's `View` type.