### PR TITLE
Add CustomDebugStringConvertible conformance to Box, Section and Node

### DIFF
--- a/Bento/Bento/Node.swift
+++ b/Bento/Bento/Node.swift
@@ -40,3 +40,9 @@ public func |---+<Identifier>(lhs: Node<Identifier>, rhs: Node<Identifier>) -> [
 public func |---+<Identifier>(lhs: [Node<Identifier>], rhs: Node<Identifier>) -> [Node<Identifier>] {
     return lhs + [rhs]
 }
+
+extension Node: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "\n*** Bento:----\(self.id)-(\(self.component.componentType))"
+    }
+}

--- a/Bento/Bento/Node.swift
+++ b/Bento/Bento/Node.swift
@@ -43,6 +43,6 @@ public func |---+<Identifier>(lhs: [Node<Identifier>], rhs: Node<Identifier>) ->
 
 extension Node: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "\n*** Bento:----\(self.id)-(\(self.component.componentType))"
+        return "\n🍱    | <\(self.id); component = \(self.component.componentType);"
     }
 }

--- a/Bento/Bento/Section.swift
+++ b/Bento/Bento/Section.swift
@@ -81,3 +81,26 @@ public struct Section<SectionID: Hashable, ItemID: Hashable> {
         return Section(id: lhs.id, items: lhs.items + rhs, supplements: lhs.supplements)
     }
 }
+
+extension Section: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        let supplementsString = supplements.map { key, value -> String in
+            let supplementType: String
+            switch key {
+            case .header:
+                supplementType = "header"
+            case .footer:
+                supplementType = "footer"
+            case let .custom(name):
+                supplementType = name
+            }
+
+            return "(\(supplementType): \(value.componentType))"
+        }.joined(separator: "-")
+
+
+        return "*** Bento:--\(self.id)\(supplementsString.isEmpty ? "" : "-")\(supplementsString)" + items.map {
+            $0.debugDescription
+        }.joined()
+    }
+}

--- a/Bento/Bento/Section.swift
+++ b/Bento/Bento/Section.swift
@@ -95,11 +95,11 @@ extension Section: CustomDebugStringConvertible {
                 supplementType = name
             }
 
-            return "(\(supplementType): \(value.componentType))"
-        }.joined(separator: "-")
+            return "\(supplementType) = \(value.componentType);"
+        }.joined(separator: " ")
 
 
-        return "*** Bento:--\(self.id)\(supplementsString.isEmpty ? "" : "-")\(supplementsString)" + items.map {
+        return "🍱 <\(self.id); \(supplementsString)" + items.map {
             $0.debugDescription
         }.joined()
     }

--- a/Bento/Views/Box.swift
+++ b/Bento/Views/Box.swift
@@ -35,3 +35,11 @@ public struct Box<SectionID: Hashable, ItemID: Hashable> {
         return Box(sections: lhs.sections + [rhs])
     }
 }
+
+extension Box: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "*** Bento: Box start" + sections.map {
+            "\n" + $0.debugDescription
+        }.joined() + "\n"
+    }
+}

--- a/Bento/Views/Box.swift
+++ b/Bento/Views/Box.swift
@@ -38,8 +38,8 @@ public struct Box<SectionID: Hashable, ItemID: Hashable> {
 
 extension Box: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "*** Bento: Box start" + sections.map {
+        return "🍱 *** Bento: Box start" + sections.map {
             "\n" + $0.debugDescription
-        }.joined() + "\n"
+        }.joined() + "\n🍱 *** Bento: Box end\n"
     }
 }


### PR DESCRIPTION
This allows debugging of rendering issues that might not be easy to spot any other way. Example output (using `print`):

<details><summary>Example 1</summary>

```
*** Bento: Box start
*** Bento:--avatar-(header: Height)
*** Bento:----thumbNail-(Align)
*** Bento:--caption-(header: Height)
*** Bento:----fullName-(Container)
*** Bento:--personal-(header: Stack)
*** Bento:----healthManagement-(Stack)
*** Bento:----monitor-(Stack)
*** Bento:----clinicalRecords-(Stack)
*** Bento:--babylon-(header: Stack)
*** Bento:----subscription-(Stack)
*** Bento:----membership-(Stack)
*** Bento:----family-(Stack)
*** Bento:--social-(header: Stack)
*** Bento:----inviteFriends-(Stack)
*** Bento:----rateUs-(Stack)
*** Bento:--help-(header: Stack)
*** Bento:----faqs-(Stack)
*** Bento:--logout-(header: Height)
*** Bento:----logout-(Container)
*** Bento:--version-(header: Height)
*** Bento:----description-(Container)
```

</p>
</details>

<details><summary>Example 2</summary>

```
*** Bento: Box start
*** Bento:--message
*** Bento:----message(BabylonSDK.Chat.Message.Incoming.ID(rawValue: "9c33681a-94d6-4dac-9fb2-cbdae54d209c"))-(AttributedDescription)
*** Bento:----space20-(Height)
*** Bento:--input
*** Bento:----item(BabylonSDK.ChatInput.Option.ID(internalID: 5cd2e441-8bc6-4700-bfec-8460d8165b34))-(Container)
*** Bento:----item(BabylonSDK.ChatInput.Option.ID(internalID: 4d8a9a09-31e3-48dc-ade7-caf2161fce83))-(Container)
*** Bento:----space8-(Height)
*** Bento:--bottom
```

</p>
</details>

So `box.debugDescription` will give you this string, including new lines. `*** Bento` is so that it's easy to find or filter in Xcode console output.

Open to suggestions and improvements. 