### PR TITLE
Fix components with customInputs not being rendered

### DIFF
--- a/Bento.xcodeproj/project.pbxproj
+++ b/Bento.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		A9509880661501C40B50E453 /* TableViewHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A950970749997A21E1BF7777 /* TableViewHeaderFooterView.swift */; };
 		A9509C4FC3664040FF3649CD /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95093DB10046D731018127D /* Node.swift */; };
 		A9509FB12CAD89179FAA03B0 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = A950967CC717BBF3B02B766D /* Box.swift */; };
+		E84D0F6B22A13F450017C9EF /* CustomInputSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84D0F6A22A13F450017C9EF /* CustomInputSnapshotTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -394,6 +395,7 @@
 		A950967CC717BBF3B02B766D /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		A950970749997A21E1BF7777 /* TableViewHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderFooterView.swift; sourceTree = "<group>"; };
 		A9509BC2762C8B4277B973D8 /* TableViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewAdapter.swift; sourceTree = "<group>"; };
+		E84D0F6A22A13F450017C9EF /* CustomInputSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomInputSnapshotTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -754,6 +756,7 @@
 				7448E83B2266220A0036B2D6 /* ToggleSnapshotTests.swift */,
 				7448E837226622080036B2D6 /* SearchSnapshotTests.swift */,
 				7468960B2267629E00363024 /* DetailedDescriptionSnapshotTests.swift */,
+				E84D0F6A22A13F450017C9EF /* CustomInputSnapshotTests.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1178,6 +1181,7 @@
 				653D460B2256665000CF3E4C /* AdapterStoreTests.swift in Sources */,
 				7448E8482266220C0036B2D6 /* ActivityComponentSnapshotTests.swift in Sources */,
 				58FC4429207CF2BB00DA3614 /* TestRenderable.swift in Sources */,
+				E84D0F6B22A13F450017C9EF /* CustomInputSnapshotTests.swift in Sources */,
 				7448E8492266220C0036B2D6 /* ButtonComponentSnapshotTests.swift in Sources */,
 				7448E835226621BF0036B2D6 /* FBSnapshotTestCaseExtensions.swift in Sources */,
 				5830C5E721F22DDC0029044B /* ComponentLifecycleTests.swift in Sources */,

--- a/Bento/Decorators/CustomInputComponent.swift
+++ b/Bento/Decorators/CustomInputComponent.swift
@@ -69,7 +69,12 @@ extension CustomInputComponent {
         var focusToolbar: FocusToolbar?
         var component: AnyRenderable?
 
-        var containedView: UIView?
+        var containedView: UIView? {
+            didSet {
+                containerViewDidChange(from: oldValue, to: containedView)
+            }
+        }
+        
         var storage: [StorageKey : Any] = [:]
 
         var isDisplaying: Bool = false {

--- a/BentoTests/SnapshotTests/Components/CustomInputSnapshotTests.swift
+++ b/BentoTests/SnapshotTests/Components/CustomInputSnapshotTests.swift
@@ -3,7 +3,7 @@ import Bento
 final class CustomInputSnapshotTests: SnapshotTestCase {
     override func setUp() {
         super.setUp()
-        self.recordMode = true
+        self.recordMode = false
     }
 
     func test_component_with_customInput_visible() {
@@ -12,15 +12,14 @@ final class CustomInputSnapshotTests: SnapshotTestCase {
             placeholder: "Placeholder",
             text: nil,
             styleSheet: Component.TextInput.StyleSheet()
+        ).customInput(Component.DatePicker(
+                date: Date(),
+                minDate: Date(),
+                calendar: Calendar.current,
+                datePickerMode: .date,
+                styleSheet: Component.DatePicker.StyleSheet()
+            )
         )
-//            .customInput(Component.DatePicker(
-//                date: Date(),
-//                minDate: Date(),
-//                calendar: Calendar.current,
-//                datePickerMode: .date,
-//                styleSheet: Component.DatePicker.StyleSheet()
-//            )
-//        )
 
         verifyComponentForAllSizes(component: component)
     }

--- a/BentoTests/SnapshotTests/Components/CustomInputSnapshotTests.swift
+++ b/BentoTests/SnapshotTests/Components/CustomInputSnapshotTests.swift
@@ -1,0 +1,27 @@
+import Bento
+
+final class CustomInputSnapshotTests: SnapshotTestCase {
+    override func setUp() {
+        super.setUp()
+        self.recordMode = true
+    }
+
+    func test_component_with_customInput_visible() {
+        let component = Component.TextInput(
+            title: "Title",
+            placeholder: "Placeholder",
+            text: nil,
+            styleSheet: Component.TextInput.StyleSheet()
+        )
+//            .customInput(Component.DatePicker(
+//                date: Date(),
+//                minDate: Date(),
+//                calendar: Calendar.current,
+//                datePickerMode: .date,
+//                styleSheet: Component.DatePicker.StyleSheet()
+//            )
+//        )
+
+        verifyComponentForAllSizes(component: component)
+    }
+}

--- a/Snapshots/ReferenceImages_64/BentoTests.CustomInputSnapshotTests/test_component_with_customInput_visible_iPhone6@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoTests.CustomInputSnapshotTests/test_component_with_customInput_visible_iPhone6@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ead66fdb8e4de59fd232251c9cc6642380d4c5f40776ea10dd8efb4f9ada9ed
+size 26857

--- a/Snapshots/ReferenceImages_64/BentoTests.CustomInputSnapshotTests/test_component_with_customInput_visible_iPhone6Plus@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoTests.CustomInputSnapshotTests/test_component_with_customInput_visible_iPhone6Plus@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa74cd8ed9fe2925667ab0926c8febc9a836050b9853ff2de1dd99e234ede16c
+size 31034

--- a/Snapshots/ReferenceImages_64/BentoTests.CustomInputSnapshotTests/test_component_with_customInput_visible_iPhoneX@2x.png
+++ b/Snapshots/ReferenceImages_64/BentoTests.CustomInputSnapshotTests/test_component_with_customInput_visible_iPhoneX@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:762802af54fa6763a5ae4d6692e58436e97c56c977b87f46a30e1cd22721ac3e
+size 31982


### PR DESCRIPTION
At the moment, components that are using a customInput are not being rendered at all. 

This is happening because the `containedView` of a `CustomInputComponent.ComponentView` is not updating `BentoReusableView` since it wasn't calling `containerViewDidChange(from:new:)`.

This PR fixes that; I've also added a snapshot test in order to prevent similar issues to happen in the future.