### PR TITLE
[GW-667] Remove call to `didRenderBox` in `UICollectionView.render`.

### DIFF
--- a/Bento/Bento/UICollectionViewExtensions.swift
+++ b/Bento/Bento/UICollectionViewExtensions.swift
@@ -28,7 +28,6 @@ extension UICollectionView {
     public func render<SectionID, ItemID>(_ box: Box<SectionID, ItemID>, animated: Bool = true, completion: (() -> Void)? = nil) {
         let adapter: CollectionViewAdapterBase<SectionID, ItemID> = getAdapter()
         adapter.update(sections: box.sections, animated: animated, completion: completion)
-        didRenderBox()
     }
 
     private struct AssociatedKey {


### PR DESCRIPTION
`didRenderBox` sends a `#selector(FocusableView.neighboringFocusEligibilityDidChange)` up the responder chain, which eventually would cause a `UIKeyboardWillChangeFrameNotification` to be sent to the `UICollectionView` which is observing these notifications via `NotificationCenter.reactive.notifications(forName name: , object: )`.

If this happens as a consequence of a text field calling `resignFirstResponder`, which **also** causes a `UIKeyboardWillChangeFrameNotification` to be sent, then you can get a recursive lock exception as `NotificationCenter.reactive.notifications(forName name: , object: )` is trying to `send` recursively to the same `Observer`.

Here is an example stack trace of this happening:
![image](https://user-images.githubusercontent.com/4175766/59284279-e4d00600-8c63-11e9-91c6-1c1c052dd74b.png)

The workaround is to remove the call to `didRenderBox` in `UICollectionView.render`. This would have the side effect of breaking focus support in `UICollectionView` screens, but there appears to be no use of this feature currently.