### PR TITLE
Replacing `move` by `delete` and `insert` sections

### DIFF
--- a/Bento/Diff/CollectionViewSectionDiff.swift
+++ b/Bento/Diff/CollectionViewSectionDiff.swift
@@ -90,9 +90,8 @@ extension UICollectionView {
     }
 
     func moveSections(_ moves: [Changeset.Move]) {
-        for move in moves {
-            moveSection(move.source, toSection: move.destination)
-        }
+        deleteSections(IndexSet(moves.map { $0.source } ))
+        insertSections(IndexSet(moves.map { $0.destination }))
     }
 
     func perform(moves: [Move]) {


### PR DESCRIPTION
Move causes a crash on UIKit. Replacing it. 